### PR TITLE
[FEATRUE-06] Kakao Oauth 을 통한 User 정보 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,21 @@ repositories {
 }
 
 dependencies {
+    // data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // security && oauth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // application
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
+
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/betteriter/BetterIterApplication.java
+++ b/src/main/java/com/example/betteriter/BetterIterApplication.java
@@ -2,8 +2,10 @@ package com.example.betteriter;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class BetterIterApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/betteriter/global/config/MainConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/MainConfig.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.global.config;
-
-public class MainConfig {
-}

--- a/src/main/java/com/example/betteriter/global/config/properties/JwtProperties.java
+++ b/src/main/java/com/example/betteriter/global/config/properties/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.example.betteriter.global.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "jwt")
+@Component
+@ConstructorBinding
+@Getter @Setter
+public class JwtProperties {
+    private String secret;
+    private String accessExpiration;
+    private String refreshExpiration;
+}

--- a/src/main/java/com/example/betteriter/global/config/properties/JwtProperties.java
+++ b/src/main/java/com/example/betteriter/global/config/properties/JwtProperties.java
@@ -3,13 +3,10 @@ package com.example.betteriter.global.config.properties;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.stereotype.Component;
 
 @ConfigurationProperties(prefix = "jwt")
-@Component
-@ConstructorBinding
-@Getter @Setter
+@Getter
+@Setter
 public class JwtProperties {
     private String secret;
     private String accessExpiration;

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -1,7 +1,34 @@
 package com.example.betteriter.global.config.security;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity(debug = true)
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors()
+                .and()
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/login/callback/**", "/test")
+                .permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
                 .and()
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/login/callback/**", "/test")
+                .antMatchers("/login/callback/**")
                 .permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -1,0 +1,7 @@
+package com.example.betteriter.global.config.security;
+
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@EnableWebSecurity(debug = true)
+public class SecurityConfig {
+}

--- a/src/main/java/com/example/betteriter/global/config/security/UserAuthentication.java
+++ b/src/main/java/com/example/betteriter/global/config/security/UserAuthentication.java
@@ -1,0 +1,29 @@
+package com.example.betteriter.global.config.security;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * - Security Context Holder 에 주입되는 Authentication 을 구현한 AbstractAuthenticationToken
+ * - UserAuthentication 을 통해 Security Context Holder 로 관리 가능
+ **/
+
+@Getter
+public class UserAuthentication extends AbstractAuthenticationToken {
+    public UserAuthentication(Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+}

--- a/src/main/java/com/example/betteriter/global/config/web/WebConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/web/WebConfig.java
@@ -1,0 +1,11 @@
+package com.example.betteriter.global.config.web;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@ConfigurationPropertiesScan
+@EnableJpaAuditing
+@Configuration
+public class WebConfig {
+}

--- a/src/main/java/com/example/betteriter/global/config/web/WebConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/web/WebConfig.java
@@ -1,10 +1,8 @@
 package com.example.betteriter.global.config.web;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@ConfigurationPropertiesScan
 @EnableJpaAuditing
 @Configuration
 public class WebConfig {

--- a/src/main/java/com/example/betteriter/global/error/ErrorResponse.java
+++ b/src/main/java/com/example/betteriter/global/error/ErrorResponse.java
@@ -1,4 +1,27 @@
 package com.example.betteriter.global.error;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
 public class ErrorResponse {
+    private int code;
+    private String errorSimpleName;
+    private String msg;
+    private LocalDateTime timestamp;
+
+    public ErrorResponse(Exception exception, HttpStatus httpStatus) {
+        this.code = httpStatus.value();
+        this.errorSimpleName = exception.getClass().getSimpleName();
+        this.msg = exception.getLocalizedMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public static ErrorResponse of(Exception exception, HttpStatus httpStatus) {
+        return new ErrorResponse(exception, httpStatus);
+    }
 }

--- a/src/main/java/com/example/betteriter/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/betteriter/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.example.betteriter.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.io.IOException;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.example.betteriter")
+public class GlobalExceptionHandler {
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<ErrorResponse> ioExceptionHandler(
+            IOException exception
+    ) {
+        return ResponseEntity.internalServerError()
+                .body(ErrorResponse.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/example/betteriter/global/error/GloblaExceptionHandler.java
+++ b/src/main/java/com/example/betteriter/global/error/GloblaExceptionHandler.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.global.error;
-
-public class GloblaExceptionHandler {
-}

--- a/src/main/java/com/example/betteriter/global/util/JwtService.java
+++ b/src/main/java/com/example/betteriter/global/util/JwtService.java
@@ -1,0 +1,11 @@
+package com.example.betteriter.global.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+}

--- a/src/main/java/com/example/betteriter/main/controller/MainController.java
+++ b/src/main/java/com/example/betteriter/main/controller/MainController.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.controller;
-
-public class MainController {
-}

--- a/src/main/java/com/example/betteriter/main/dao/MainDao.java
+++ b/src/main/java/com/example/betteriter/main/dao/MainDao.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.dao;
-
-public class MainDao {
-}

--- a/src/main/java/com/example/betteriter/main/domain/entity/MainEntity.java
+++ b/src/main/java/com/example/betteriter/main/domain/entity/MainEntity.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.domain.entity;
-
-public class MainEntity {
-}

--- a/src/main/java/com/example/betteriter/main/domain/repository/MainRepository.java
+++ b/src/main/java/com/example/betteriter/main/domain/repository/MainRepository.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.domain.repository;
-
-public interface MainRepository {
-}

--- a/src/main/java/com/example/betteriter/main/dto/MainDto.java
+++ b/src/main/java/com/example/betteriter/main/dto/MainDto.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.dto;
-
-public class MainDto {
-}

--- a/src/main/java/com/example/betteriter/main/exception/MainException.java
+++ b/src/main/java/com/example/betteriter/main/exception/MainException.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.exception;
-
-public class MainException {
-}

--- a/src/main/java/com/example/betteriter/main/service/MainService.java
+++ b/src/main/java/com/example/betteriter/main/service/MainService.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.main.service;
-
-public class MainService {
-}

--- a/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
@@ -1,0 +1,25 @@
+package com.example.betteriter.user.controller;
+
+import com.example.betteriter.user.dto.UserOauthLoginResponseDto;
+import com.example.betteriter.user.service.KakaoOauthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class KakaoOauthController {
+
+    private final KakaoOauthService kakaoOauthService;
+
+    @GetMapping("/login/callback/kakao")
+    public ResponseEntity<UserOauthLoginResponseDto> kakaoOauthLogin(
+            @RequestParam String code
+    ) {
+        return ResponseEntity.ok(this.kakaoOauthService.kakaoOauthLogin(code));
+    }
+}

--- a/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
@@ -22,4 +22,9 @@ public class KakaoOauthController {
     ) {
         return ResponseEntity.ok(this.kakaoOauthService.kakaoOauthLogin(code));
     }
+
+    @GetMapping("/test")
+    public ResponseEntity<Void> test() {
+        return ResponseEntity.ok(this.kakaoOauthService.test());
+    }
 }

--- a/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -19,12 +21,7 @@ public class KakaoOauthController {
     @GetMapping("/login/callback/kakao")
     public ResponseEntity<UserOauthLoginResponseDto> kakaoOauthLogin(
             @RequestParam String code
-    ) {
+    ) throws IOException {
         return ResponseEntity.ok(this.kakaoOauthService.kakaoOauthLogin(code));
-    }
-
-    @GetMapping("/test")
-    public ResponseEntity<Void> test() {
-        return ResponseEntity.ok(this.kakaoOauthService.test());
     }
 }

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -1,0 +1,24 @@
+package com.example.betteriter.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Slf4j
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "USERS")
+public class User {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -1,15 +1,15 @@
 package com.example.betteriter.user.domain;
 
+import com.example.betteriter.user.dto.RoleType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Getter
@@ -19,6 +19,32 @@ import javax.persistence.Id;
 @Entity(name = "USERS")
 public class User {
     @Id
-    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "usr_oauth_id", unique = true)
+    private String oauthId;
+
+    @Column(name = "usr_email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "usr_pwd", unique = true)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "usr_role")
+    private RoleType role;
+
+    // 기타 회원 정보
+    @Column(name = "usr_nickname", unique = true)
+    private String nickName;
+
+    @Column(name = "usr_age")
+    private int age;
+
+    @Column(name = "usr_job")
+    private int job;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    private List<Integer> interests = new ArrayList<>();
 }

--- a/src/main/java/com/example/betteriter/user/dto/RoleType.java
+++ b/src/main/java/com/example/betteriter/user/dto/RoleType.java
@@ -1,0 +1,8 @@
+package com.example.betteriter.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum RoleType {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/example/betteriter/user/dto/UserOauthLoginResponseDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/UserOauthLoginResponseDto.java
@@ -5,6 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+
+/**
+ * - oauth 로그인 후 응답 객체
+ **/
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/example/betteriter/user/dto/UserOauthLoginResponseDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/UserOauthLoginResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.betteriter.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class UserOauthLoginResponseDto {
+}

--- a/src/main/java/com/example/betteriter/user/dto/info/KakaoOauthUserInfo.java
+++ b/src/main/java/com/example/betteriter/user/dto/info/KakaoOauthUserInfo.java
@@ -1,0 +1,31 @@
+package com.example.betteriter.user.dto.info;
+
+import java.util.Map;
+
+/**
+ * - https://kapi.kakao.com/user/me 로 가져온 사용자 정보 가공
+ **/
+public class KakaoOauthUserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public KakaoOauthUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getProvider() {
+        return "kakao";
+    }
+
+    public String getOauthId() {
+        return String.valueOf(this.attributes.get("id"));
+    }
+
+    public String getKakaoEmail() {
+        return String.valueOf(getKakaoAccount().get("email"));
+    }
+
+    public Map<String, Object> getKakaoAccount() {
+        return (Map<String, Object>) attributes.get("kakao_account");
+    }
+}

--- a/src/main/java/com/example/betteriter/user/dto/oauth/KakaoToken.java
+++ b/src/main/java/com/example/betteriter/user/dto/oauth/KakaoToken.java
@@ -1,0 +1,28 @@
+package com.example.betteriter.user.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+/**
+ * - Kakao oauth server 부터 받아온 JWT
+ * 1. token-type
+ * 2. access-token
+ * 3. refresh-token
+ * 4. expires-in
+ * 5. refresh-expires-in
+ **/
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoToken {
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/example/betteriter/user/exception/MainException.java
+++ b/src/main/java/com/example/betteriter/user/exception/MainException.java
@@ -1,0 +1,4 @@
+package com.example.betteriter.user.exception;
+
+public class MainException {
+}

--- a/src/main/java/com/example/betteriter/user/repository/UserRepository.java
+++ b/src/main/java/com/example/betteriter/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.betteriter.user.repository;
+
+import com.example.betteriter.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+}

--- a/src/main/java/com/example/betteriter/user/repository/UserRepository.java
+++ b/src/main/java/com/example/betteriter/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.example.betteriter.user.repository;
 import com.example.betteriter.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User,Long> {
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByOauthId(String oauthId);
 }

--- a/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
+++ b/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
@@ -1,5 +1,6 @@
 package com.example.betteriter.user.service;
 
+import com.example.betteriter.global.config.properties.JwtProperties;
 import com.example.betteriter.global.util.JwtService;
 import com.example.betteriter.user.repository.UserRepository;
 import com.example.betteriter.user.dto.UserOauthLoginResponseDto;
@@ -15,12 +16,23 @@ public class KakaoOauthService {
     private final UserRepository userRepository;
     private final JwtService jwtService;
     private final InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
+    private final JwtProperties jwtProperties;
 
     /**
      * - kakao 로그인 후 jwt 발급하는 로직
      * - kakao oauth server 에 jwt 을 요청하고 받아서 https://kapi.kakao.com/user/me
     **/
     public UserOauthLoginResponseDto kakaoOauthLogin(String code) {
+        log.info(this.jwtProperties.getAccessExpiration());
+        log.info(this.jwtProperties.getRefreshExpiration());
+        log.info(this.jwtProperties.getSecret());
+        return null;
+    }
+
+    public Void test() {
+        log.info(this.jwtProperties.getAccessExpiration());
+        log.info(this.jwtProperties.getRefreshExpiration());
+        log.info(this.jwtProperties.getSecret());
         return null;
     }
 }

--- a/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
+++ b/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
@@ -2,37 +2,116 @@ package com.example.betteriter.user.service;
 
 import com.example.betteriter.global.config.properties.JwtProperties;
 import com.example.betteriter.global.util.JwtService;
-import com.example.betteriter.user.repository.UserRepository;
+import com.example.betteriter.user.domain.User;
+import com.example.betteriter.user.dto.RoleType;
 import com.example.betteriter.user.dto.UserOauthLoginResponseDto;
+import com.example.betteriter.user.dto.info.KakaoOauthUserInfo;
+import com.example.betteriter.user.dto.oauth.KakaoToken;
+import com.example.betteriter.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class KakaoOauthService {
     private final UserRepository userRepository;
-    private final JwtService jwtService;
     private final InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
+    private final JwtService jwtService;
     private final JwtProperties jwtProperties;
 
-    /**
-     * - kakao 로그인 후 jwt 발급하는 로직
-     * - kakao oauth server 에 jwt 을 요청하고 받아서 https://kapi.kakao.com/user/me
-    **/
-    public UserOauthLoginResponseDto kakaoOauthLogin(String code) {
-        log.info(this.jwtProperties.getAccessExpiration());
-        log.info(this.jwtProperties.getRefreshExpiration());
-        log.info(this.jwtProperties.getSecret());
+    public UserOauthLoginResponseDto kakaoOauthLogin(String code) throws IOException {
+        User user = findUser(code);
         return null;
     }
 
-    public Void test() {
-        log.info(this.jwtProperties.getAccessExpiration());
-        log.info(this.jwtProperties.getRefreshExpiration());
-        log.info(this.jwtProperties.getSecret());
-        return null;
+    private User findUser(String code) throws IOException {
+        ClientRegistration kakaoClientRegistration
+                = this.inMemoryClientRegistrationRepository.findByRegistrationId("kakao");
+        KakaoToken kakaoToken = getKakaoToken(code, kakaoClientRegistration);
+        return saveUserWithKakaoUserInfo(kakaoToken, kakaoClientRegistration);
+    }
+
+
+    /**
+     * step 01 : 카카오 jwt 요청
+     * - https://kauth.kakao.com/oauth/token
+     * - application/x-www-form-urlencoded
+     **/
+    private KakaoToken getKakaoToken(String code, ClientRegistration kakaoClientRegistration) {
+        return WebClient.create()
+                .post()
+                .uri(kakaoClientRegistration.getProviderDetails().getTokenUri())
+                .headers(h -> {
+                    h.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    h.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(kakaoTokenRequest(code, kakaoClientRegistration))
+                .retrieve()
+                .bodyToMono(KakaoToken.class)
+                .block();
+    }
+
+    /**
+     * - post request body
+     * 1. code : 받은 인가 코드
+     * 2. redirect-uri : 설정한 리다이렉트 주소
+     * 3. grant-type : authorization_code
+     * 4. client-id : rest api 앱 키
+     * 5. client-secret : 받는 토큰 보안 강화
+     **/
+    private MultiValueMap<String, String> kakaoTokenRequest(String code, ClientRegistration kakaoClientRegistration) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("redirect_uri", kakaoClientRegistration.getRedirectUri());
+        formData.add("grant_type", kakaoClientRegistration.getAuthorizationGrantType().getValue());
+        formData.add("client_id", kakaoClientRegistration.getClientId());
+        formData.add("client_secret", kakaoClientRegistration.getClientSecret());
+        return formData;
+    }
+
+    /**
+     * step 02 : 카카오 jwt 을 가지고 회원정보 요청
+     * - https://kapi.kakao.com/user/me
+     * - kakao auth server 에 존재하는 내정보를 이용해서 회원 엔티티 생성
+     **/
+    private User saveUserWithKakaoUserInfo(KakaoToken kakaoToken,
+                                           ClientRegistration kakaoClientRegistration) throws IOException {
+        Map<String, Object> attributes = getUserAttributes(kakaoToken, kakaoClientRegistration);
+        System.out.println(attributes);
+        KakaoOauthUserInfo kakaoOauthUserInfo = new KakaoOauthUserInfo(attributes);
+        String oauthId = kakaoOauthUserInfo.getOauthId();
+        String kakaoEmail = kakaoOauthUserInfo.getKakaoEmail();
+        return this.userRepository.findByOauthId(oauthId).orElseGet(() -> this.userRepository.save(
+                User.builder()
+                        .oauthId(oauthId)
+                        .email(kakaoEmail)
+                        .role(RoleType.ROLE_USER)
+                        .build()));
+    }
+
+    /* 실제 회원 정보 가져오기 */
+    private Map<String, Object> getUserAttributes(KakaoToken kakaoToken, ClientRegistration kakaoClientRegistration) {
+        return WebClient.create()
+                .get()
+                .uri(kakaoClientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(h -> h.setBearerAuth(kakaoToken.getAccessToken()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
     }
 }

--- a/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
+++ b/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
@@ -1,0 +1,26 @@
+package com.example.betteriter.user.service;
+
+import com.example.betteriter.global.util.JwtService;
+import com.example.betteriter.user.repository.UserRepository;
+import com.example.betteriter.user.dto.UserOauthLoginResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoOauthService {
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
+
+    /**
+     * - kakao 로그인 후 jwt 발급하는 로직
+     * - kakao oauth server 에 jwt 을 요청하고 받아서 https://kapi.kakao.com/user/me
+    **/
+    public UserOauthLoginResponseDto kakaoOauthLogin(String code) {
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,8 +38,7 @@ spring:
             client-authentication-method: POST
             authorization-grant-type: authorization_code
             scope:
-              - profile_nickname
-              - profile_image
+              - account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,10 +49,8 @@ spring:
 ### JWT
 jwt:
   secret: ${JWT_SECRET_KEY}
-  access:
-    expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1시간
-  refresh:
-    expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1일
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1시간
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1일
 
 
 logging:


### PR DESCRIPTION
### PR 제목

- Kakao Oauth 을 이용하여 jwt 발급 받아 서비스 유저 정보 저장 구현

### PR 생성 날짜

- 2023/09/22

### PR 내용

- step 01. 인가 코드로 토큰 발급 요청
- step 02. 받은 토큰을 이용해서 회원 정보 요청
- step 03. 받은 회원 정보를 가공해서 UserRepository 저장

### 첨부 자료  

- x

### 관련 이슈

- close #6 