### PR TITLE
[FEATURE-19] 회원 인증 기능 및 회원 일반 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/betteriter/example/domain/Temp.java
+++ b/src/main/java/com/example/betteriter/example/domain/Temp.java
@@ -1,50 +1,50 @@
-package com.example.betteriter.example.domain;
-
-import com.example.betteriter.user.dto.RoleType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
-
-@Slf4j
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-@Entity(name = "USERS")
-public class Temp {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "usr_oauth_id", unique = true)
-    private String oauthId;
-
-    @Column(name = "usr_email", nullable = false, unique = true)
-    private String email;
-
-    @Column(name = "usr_pwd", unique = true)
-    private String password;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "usr_role")
-    private RoleType role;
-
-    // 기타 회원 정보
-    @Column(name = "usr_nickname", unique = true)
-    private String nickName;
-
-    @Column(name = "usr_age")
-    private int age;
-
-    @Column(name = "usr_job")
-    private int job;
-
-    @ElementCollection(fetch = FetchType.LAZY)
-    private List<Integer> interests = new ArrayList<>();
-}
+//package com.example.betteriter.example.domain;
+//
+//import com.example.betteriter.user.dto.RoleType;
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//
+//import javax.persistence.*;
+//import java.util.ArrayList;
+//import java.util.List;
+//
+//@Slf4j
+//@Getter
+//@Builder
+//@AllArgsConstructor
+//@NoArgsConstructor
+//@Entity(name = "USERS")
+//public class Temp {
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @Column(name = "usr_oauth_id", unique = true)
+//    private String oauthId;
+//
+//    @Column(name = "usr_email", nullable = false, unique = true)
+//    private String email;
+//
+//    @Column(name = "usr_pwd", unique = true)
+//    private String password;
+//
+//    @Enumerated(EnumType.STRING)
+//    @Column(name = "usr_role")
+//    private RoleType role;
+//
+//    // 기타 회원 정보
+//    @Column(name = "usr_nickname", unique = true)
+//    private String nickName;
+//
+//    @Column(name = "usr_age")
+//    private int age;
+//
+//    @Column(name = "usr_job")
+//    private int job;
+//
+//    @ElementCollection(fetch = FetchType.LAZY)
+//    private List<Integer> interests = new ArrayList<>();
+//}

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/login/callback/**", "/user/**").permitAll() // 특정 URI 예외 처리
+                .antMatchers("/login/callback/**", "/auth/**").permitAll() // 특정 URI 예외 처리
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/login/callback/**").permitAll() // 특정 URI 예외 처리
+                .antMatchers("/login/callback/**", "/user/**").permitAll() // 특정 URI 예외 처리
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -21,6 +22,12 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .antMatchers("/css/**", "/js/**", "/img/**", "/error", "/favicon.ico", "/resources/**");
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors()
@@ -31,16 +38,16 @@ public class SecurityConfig {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/login/callback/**").permitAll()
+                .antMatchers("/login/callback/**").permitAll() // 특정 URI 예외 처리
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .and()
                 .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-
-        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
+
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -5,6 +5,8 @@ import com.example.betteriter.global.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -25,6 +27,11 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .antMatchers("/css/**", "/js/**", "/img/**", "/error", "/favicon.ico", "/resources/**");
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean

--- a/src/main/java/com/example/betteriter/global/config/security/UserAuthentication.java
+++ b/src/main/java/com/example/betteriter/global/config/security/UserAuthentication.java
@@ -37,6 +37,11 @@ public class UserAuthentication extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return null;
+        return userId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
     }
 }

--- a/src/main/java/com/example/betteriter/global/config/security/UserAuthentication.java
+++ b/src/main/java/com/example/betteriter/global/config/security/UserAuthentication.java
@@ -11,17 +11,17 @@ import java.util.List;
 
 /**
  * - Security Context Holder 에 주입되는 Authentication 을 구현한 AbstractAuthenticationToken
- * - UserAuthentication 을 통해 Security Context Holder 로 관리 가능
+ * - 인증 후 UserAuthentication 을 SecurityContext 에 저장 시, Security Context Holder 로 어디서든 접근 가능 !!
  **/
 
 @Getter
 public class UserAuthentication extends AbstractAuthenticationToken {
 
-    private final Long userId;
+    private final String userEmail;
 
     public UserAuthentication(User user) {
         super(authorities(user));
-        this.userId = user.getId();
+        this.userEmail = user.getEmail();
     }
 
     private static List<GrantedAuthority> authorities(User user) {
@@ -37,7 +37,7 @@ public class UserAuthentication extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return userId;
+        return userEmail;
     }
 
     @Override

--- a/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationFilter.java
@@ -51,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain)
             throws ServletException, IOException {
-        if (request.getMethod().equals("OPTIONS") || request.getRequestURI().equals("/login/callback/kakao")) {
+        if (request.getMethod().equals("OPTIONS")) {
             filterChain.doFilter(request, response);
             // 이후 현재 필터 진행 방지
             return;
@@ -78,8 +78,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // Case 02) 일반 API 요청인 경우
         else {
             checkAccessTokenAndAuthentication(request, response, filterChain);
+            log.info("API 요청 예외 없이 정상 처리");
         }
 
+        log.info("다음 필터로 넘어가기전");
+        log.info("hh");
         // Authentication Exception 없이 정상 인증처리 된 경우
         filterChain.doFilter(request, response);
     }
@@ -155,14 +158,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             User user = this.userRepository.findById(Long.valueOf(this.jwtUtil.getUserIdFromToken(accessToken)))
                     .orElseThrow(() -> new UsernameNotFoundException("usernameNotFoundException"));
-            saveAuthentication(user);
+
+            // SecurityContext 에 인증된 Authentication 저장
+            UserAuthentication authentication = new UserAuthentication(user);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (IllegalArgumentException | JwtException | UsernameNotFoundException exception) {
             request.setAttribute("UnauthorizedUserException", exception);
         }
-    }
-
-    private void saveAuthentication(User user) {
-        UserAuthentication userAuthentication = new UserAuthentication(user);
-        SecurityContextHolder.getContext().setAuthentication(userAuthentication);
     }
 }

--- a/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationFilter.java
@@ -81,8 +81,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("API 요청 예외 없이 정상 처리");
         }
 
-        log.info("다음 필터로 넘어가기전");
-        log.info("hh");
+        log.info("passed to next filter");
         // Authentication Exception 없이 정상 인증처리 된 경우
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/betteriter/global/util/JwtUtil.java
+++ b/src/main/java/com/example/betteriter/global/util/JwtUtil.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 @Service
 public class JwtUtil {
     private final JwtProperties jwtProperties;
+    private final RedisUtil redisUtil;
 
     // HttpServletRequest 부터 Access Token 추출
     public Optional<String> extractAccessToken(HttpServletRequest request) {
@@ -72,7 +73,7 @@ public class JwtUtil {
         String refreshToken = this.createRefreshToken();
 
         LocalDateTime expireTime = LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000);
-
+        this.redisUtil.setData(String.valueOf(user.getId()), refreshToken);
         return UserServiceTokenResponseDto.builder()
                 .accessToken(this.jwtProperties.getBearer() + " " + accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/com/example/betteriter/global/util/JwtUtil.java
+++ b/src/main/java/com/example/betteriter/global/util/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.example.betteriter.global.util;
 
 import com.example.betteriter.global.config.properties.JwtProperties;
+import com.example.betteriter.user.domain.User;
+import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -60,6 +64,20 @@ public class JwtUtil {
             log.error("Access Token is not valid");
         }
         return null;
+    }
+
+    // kakao oauth 로그인 & 일반 로그인 시 jwt 응답 생성
+    public UserServiceTokenResponseDto getServiceToken(User user) {
+        String accessToken = this.createAccessToken(String.valueOf(user.getId()));
+        String refreshToken = this.createRefreshToken();
+
+        LocalDateTime expireTime = LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000);
+
+        return UserServiceTokenResponseDto.builder()
+                .accessToken(this.jwtProperties.getBearer() + " " + accessToken)
+                .refreshToken(refreshToken)
+                .expiredTime(expireTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .build();
     }
 
     // token 유효성 검증

--- a/src/main/java/com/example/betteriter/global/util/SecurityUtil.java
+++ b/src/main/java/com/example/betteriter/global/util/SecurityUtil.java
@@ -1,0 +1,25 @@
+package com.example.betteriter.global.util;
+
+import com.example.betteriter.global.config.security.UserAuthentication;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collection;
+
+@Slf4j
+@NoArgsConstructor
+public class SecurityUtil {
+    public static String getCurrentUserEmail() {
+        UserAuthentication authentication
+                = (UserAuthentication) SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getUserEmail();
+    }
+
+    public static Collection<GrantedAuthority> getUserAuthorities() {
+        UserAuthentication authentication
+                = (UserAuthentication) SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getAuthorities();
+    }
+}

--- a/src/main/java/com/example/betteriter/infra/Email.java
+++ b/src/main/java/com/example/betteriter/infra/Email.java
@@ -1,4 +1,0 @@
-package com.example.betteriter.infra;
-
-public class Email {
-}

--- a/src/main/java/com/example/betteriter/infra/EmailAuthenticationDto.java
+++ b/src/main/java/com/example/betteriter/infra/EmailAuthenticationDto.java
@@ -1,0 +1,13 @@
+package com.example.betteriter.infra;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailAuthenticationDto {
+    private String email;
+    private int code;
+}

--- a/src/main/java/com/example/betteriter/infra/EmailDto.java
+++ b/src/main/java/com/example/betteriter/infra/EmailDto.java
@@ -1,0 +1,17 @@
+package com.example.betteriter.infra;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailDto {
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/example/betteriter/infra/EmailService.java
+++ b/src/main/java/com/example/betteriter/infra/EmailService.java
@@ -1,0 +1,82 @@
+package com.example.betteriter.infra;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class EmailService {
+    private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String mailSender;
+
+    // 회원가입인 경우, 인증을 위한 이메일 전송
+    public void sendEmailForJoin(String toEmail,
+                                 String code) {
+        MimeMessage emailForm = createEmailForJoin(toEmail, code);
+        this.javaMailSender.send(emailForm);
+    }
+
+    // 비밀번호 재설정인 경우, 인증을 위한 이메일 전송
+    public void sendEmailForResetPassword(String toEmail,
+                                          String code) {
+        MimeMessage emailForm = createEmailForResetPassword(toEmail, code);
+        this.javaMailSender.send(emailForm);
+    }
+
+
+    private MimeMessage createEmailForJoin(String toEmail, String code) {
+        MimeMessage message = this.javaMailSender.createMimeMessage();
+
+        String title = "[ITer] 인증번호를 안내해드립니다.";
+        String text = "<h2>[ITer] 인증번호를 안내해드립니다.</h2><br>\n" +
+                "    <p> 저희 ITer 서비스 <u><strong>신규 등록을 위해</strong></u> 이메일 인증이 필요합니다.</p>" +
+                "    <p> 아래 인증 번호를 확인하신 후 이메일 인증절차를 완료해주세요. </p><br>" +
+                "    <h3>인증번호 : <strong>" + code + "</strong></h3><br>" +
+                "    <p>항상 ITer에 관심을 가져주시고 이용해 주셔서 감사합니다.</p>\n" +
+                "    <p><em>Better team.</em></p>";
+
+        try {
+            message.setFrom(mailSender);
+            message.setRecipients(MimeMessage.RecipientType.TO, toEmail);
+            message.setSubject(title);
+            message.setText(text, "UTF-8", "html");
+        } catch (MessagingException exception) {
+            log.debug("EmailService.createEmailForJoin() exception occurs");
+            throw new RuntimeException("EmailService Exception Occurs");
+        }
+        return message;
+    }
+
+
+    private MimeMessage createEmailForResetPassword(String toEmail, String code) {
+        MimeMessage message = this.javaMailSender.createMimeMessage();
+
+        String title = "[ITer] 인증번호를 안내해드립니다.";
+        String text = "<h2>[ITer] 인증번호를 안내해드립니다.</h2><br>\n" +
+                "    <p> 저희 ITer 서비스 <u><strong>비밀번호 재설정을 위해</strong></u> 이메일 인증이 필요합니다.</p>" +
+                "    <p> 아래 인증 번호를 확인하신 후 이메일 인증절차를 완료해주세요.</p><br>" +
+                "    <h3>인증 번호 : <strong>" + code + "</strong></h3><br>" +
+                "    <p>항상 ITer에 관심을 가져주시고 이용해 주셔서 감사합니다.</p>\n" +
+                "    <p><em>Better team.</em></p>";
+
+        try {
+            message.setFrom(mailSender);
+            message.setRecipients(MimeMessage.RecipientType.TO, toEmail);
+            message.setSubject(title);
+            message.setText(text, "UTF-8", "html");
+        } catch (MessagingException exception) {
+            log.debug("EmailService.createEmailForResetPassword() exception occurs");
+            throw new RuntimeException("EmailService Exception Occurs");
+        }
+        return message;
+    }
+}

--- a/src/main/java/com/example/betteriter/user/controller/AuthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/AuthController.java
@@ -1,0 +1,108 @@
+package com.example.betteriter.user.controller;
+
+import com.example.betteriter.infra.EmailAuthenticationDto;
+import com.example.betteriter.infra.EmailDto;
+import com.example.betteriter.user.dto.JoinDto;
+import com.example.betteriter.user.dto.LoginDto;
+import com.example.betteriter.user.dto.PasswordResetRequestDto;
+import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
+import com.example.betteriter.user.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+/**
+ * - 회원 회원가입/로그인 등 인증,인가와 관련된 작
+ **/
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 1. 일반 회원가입
+     * - 서비스에서 사용자 인증 정보 관리 컨트롤러
+     * - 이미 회원가입된 사용자는 에러처리
+     * - /auth/join
+     **/
+    @PostMapping("/join")
+    public ResponseEntity<Long> join(
+            @RequestBody @Valid JoinDto request) {
+        return new ResponseEntity<>(this.authService.join(request), HttpStatus.CREATED);
+    }
+
+    /**
+     * 2. 회원가입을 위한 이메일 인증 요청
+     * - 사용자가 일반 회원가입에서 입력한 이메일을 통한 인증 컨트롤러
+     * - 해당 이메일 중복 여부 판단 후, 인증 번호 전송
+     * 과정 : 클라이언트 이메일 입력 및 인증 버튼 클릭 -> 서버로 해당 이메일과 함께 API 요청 ->
+     * -> 해당 이메일을 가진 회원이 있는지 중복 체크 -> 없다면 인증 코드 이메일로 전송 ->
+     * 사용자가 인증 번호 클릭 -> 서버에서 판단 후 승인 or 거부
+     */
+    @PostMapping("/join/emails")
+    public ResponseEntity<Void> requestEmail(
+            @RequestBody @Valid EmailDto emailDto
+    ) {
+        this.authService.requestEmailForJoin(emailDto);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 3. 인증 코드 검증
+     * - 사용자가 이메일로 받은 인증 코드 검증하는 컨트롤러
+     * - 회원가입 & 비밀번호 재설정 모두 사용
+     * - /auth/check/code
+     **/
+    @PostMapping("/emails/verification")
+    public ResponseEntity<Void> verifyAuthCode(
+            @RequestBody @Valid EmailAuthenticationDto emailAuthenticationDto
+    ) {
+        this.authService.verifyAuthCode(emailAuthenticationDto);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 4. 로그인
+     * - /auth/login
+     **/
+    @PostMapping("/login")
+    public ResponseEntity<UserServiceTokenResponseDto> login(
+            @RequestBody @Valid LoginDto loginRequestDto) {
+        return new ResponseEntity<>(this.authService.login(loginRequestDto), HttpStatus.OK);
+    }
+
+    /**
+     * 5. 비밀번호 재설정 이메일 인증 요청 컨트롤러
+     * - /auth/password/emails
+     * - 비밀번호 재설정을 위한 이메일 요청 이미 해당 회원정보가 있어야 함
+     **/
+    @PostMapping("/password/emails")
+    public ResponseEntity<Void> requestEmailForPassword(
+            @RequestBody @Valid EmailDto emailDto
+    ) {
+        this.authService.requestEmailForPassword(emailDto);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 6. 비밀번호 재설정 요청 컨트롤러
+     * - /auth/password/reset
+     * - 새로운 비밀번호를 입력받아 설정
+     * - 해당 유저가 존재 여부 확인 및 일반 회원가입 유저인지 다시 확인
+     **/
+    @PatchMapping("/password/reset")
+    public ResponseEntity<Void> resetPassword(
+            @RequestBody PasswordResetRequestDto request
+    ) {
+        this.authService.resetPassword(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
@@ -1,6 +1,6 @@
 package com.example.betteriter.user.controller;
 
-import com.example.betteriter.user.dto.UserOauthLoginResponseDto;
+import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
 import com.example.betteriter.user.service.KakaoOauthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +19,7 @@ public class KakaoOauthController {
     private final KakaoOauthService kakaoOauthService;
 
     @GetMapping("/login/callback/kakao")
-    public ResponseEntity<UserOauthLoginResponseDto> kakaoOauthLogin(
+    public ResponseEntity<UserServiceTokenResponseDto> kakaoOauthLogin(
             @RequestParam String code
     ) throws IOException {
         return ResponseEntity.ok(this.kakaoOauthService.kakaoOauthLogin(code));

--- a/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
@@ -24,10 +24,4 @@ public class KakaoOauthController {
     ) throws IOException {
         return ResponseEntity.ok(this.kakaoOauthService.kakaoOauthLogin(code));
     }
-
-    @GetMapping("/test")
-    public String test() {
-        log.info("테스트 성공!");
-        return "테스트 성공!";
-    }
 }

--- a/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/user/controller/KakaoOauthController.java
@@ -27,6 +27,7 @@ public class KakaoOauthController {
 
     @GetMapping("/test")
     public String test() {
+        log.info("테스트 성공!");
         return "테스트 성공!";
     }
 }

--- a/src/main/java/com/example/betteriter/user/controller/UserController.java
+++ b/src/main/java/com/example/betteriter/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.betteriter.user.controller;
 
 
+import com.example.betteriter.user.dto.EmailDto;
 import com.example.betteriter.user.dto.JoinDto;
 import com.example.betteriter.user.dto.LoginDto;
 import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
@@ -9,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -27,6 +25,7 @@ public class UserController {
     /**
      * 1. 일반 회원가입
      * - 서비스에서 사용자 인증 정보 관리
+     * - 이미 회원가입된 사용자는 에러처리
      * - /user/join
      **/
     @PostMapping("/join")
@@ -36,12 +35,48 @@ public class UserController {
     }
 
     /**
-     * 2. 로그인
+     * 2. 이메일 인증
+     * - 사용자가 일반 회원가입에서 입력한 이메일을 통한 인증 로직
+     * -
+     */
+    @PostMapping("/email")
+    public ResponseEntity<Void> email(
+            @RequestBody @Valid EmailDto emailDto
+    ) {
+        this.userService.email(emailDto);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 3. 로그인
      * - /user/login
      **/
     @PostMapping("/login")
     public ResponseEntity<UserServiceTokenResponseDto> login(
             @RequestBody @Valid LoginDto loginRequestDto) {
         return new ResponseEntity<>(this.userService.login(loginRequestDto), HttpStatus.OK);
+    }
+
+    /**
+     * 4. 로그아웃
+     * - /user/logout
+     * 1. 프론트에서 가지고 있는 Access Token 삭제
+     * 2. 백에서 Refresh Token 삭제
+     **/
+    @PostMapping("/logout")
+    public ResponseEntity<Long> logout() {
+        return new ResponseEntity<>(this.userService.logout(), HttpStatus.OK);
+    }
+
+    /**
+     * 5. 회원 탈퇴
+     * - /user/withdraw
+     * 1. 프론트에서 가지고 있는 Access Token 삭제
+     * 2. User 정보 삭제
+     **/
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw() {
+        this.userService.withdraw();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/betteriter/user/controller/UserController.java
+++ b/src/main/java/com/example/betteriter/user/controller/UserController.java
@@ -1,0 +1,47 @@
+package com.example.betteriter.user.controller;
+
+
+import com.example.betteriter.user.dto.JoinDto;
+import com.example.betteriter.user.dto.LoginDto;
+import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
+import com.example.betteriter.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/user")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 1. 일반 회원가입
+     * - 서비스에서 사용자 인증 정보 관리
+     * - /user/join
+     **/
+    @PostMapping("/join")
+    public ResponseEntity<Long> join(
+            @RequestBody @Valid JoinDto request) {
+        return new ResponseEntity<>(this.userService.join(request), HttpStatus.CREATED);
+    }
+
+    /**
+     * 2. 로그인
+     * - /user/login
+     **/
+    @PostMapping("/login")
+    public ResponseEntity<UserServiceTokenResponseDto> login(
+            @RequestBody @Valid LoginDto loginRequestDto) {
+        return new ResponseEntity<>(this.userService.login(loginRequestDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/betteriter/user/controller/UserController.java
+++ b/src/main/java/com/example/betteriter/user/controller/UserController.java
@@ -1,18 +1,15 @@
 package com.example.betteriter.user.controller;
 
 
-import com.example.betteriter.user.dto.EmailDto;
-import com.example.betteriter.user.dto.JoinDto;
-import com.example.betteriter.user.dto.LoginDto;
-import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
 import com.example.betteriter.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,42 +20,7 @@ public class UserController {
     private final UserService userService;
 
     /**
-     * 1. 일반 회원가입
-     * - 서비스에서 사용자 인증 정보 관리
-     * - 이미 회원가입된 사용자는 에러처리
-     * - /user/join
-     **/
-    @PostMapping("/join")
-    public ResponseEntity<Long> join(
-            @RequestBody @Valid JoinDto request) {
-        return new ResponseEntity<>(this.userService.join(request), HttpStatus.CREATED);
-    }
-
-    /**
-     * 2. 이메일 인증
-     * - 사용자가 일반 회원가입에서 입력한 이메일을 통한 인증 로직
-     * -
-     */
-    @PostMapping("/email")
-    public ResponseEntity<Void> email(
-            @RequestBody @Valid EmailDto emailDto
-    ) {
-        this.userService.email(emailDto);
-        return ResponseEntity.ok().build();
-    }
-
-    /**
-     * 3. 로그인
-     * - /user/login
-     **/
-    @PostMapping("/login")
-    public ResponseEntity<UserServiceTokenResponseDto> login(
-            @RequestBody @Valid LoginDto loginRequestDto) {
-        return new ResponseEntity<>(this.userService.login(loginRequestDto), HttpStatus.OK);
-    }
-
-    /**
-     * 4. 로그아웃
+     * 1. 로그아웃
      * - /user/logout
      * 1. 프론트에서 가지고 있는 Access Token 삭제
      * 2. 백에서 Refresh Token 삭제
@@ -69,7 +31,7 @@ public class UserController {
     }
 
     /**
-     * 5. 회원 탈퇴
+     * 2. 회원 탈퇴
      * - /user/withdraw
      * 1. 프론트에서 가지고 있는 Access Token 삭제
      * 2. User 정보 삭제
@@ -79,4 +41,5 @@ public class UserController {
         this.userService.withdraw();
         return ResponseEntity.ok().build();
     }
+
 }

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -1,21 +1,23 @@
 package com.example.betteriter.user.domain;
 
 import com.example.betteriter.user.dto.RoleType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @Slf4j
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "USERS")
-public class User {
+public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,6 +42,36 @@ public class User {
     @Column(name = "usr_job")
     private int job;
 
-//    @ElementCollection(fetch = FetchType.LAZY)
-//    private List<Integer> interests = new ArrayList<>();
+    @ElementCollection(fetch = FetchType.LAZY)
+    private List<Integer> interests = new ArrayList<>();
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(this.id);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -4,12 +4,12 @@ import com.example.betteriter.user.dto.RoleType;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 @Slf4j
 @Getter
@@ -35,24 +35,29 @@ public class User implements UserDetails {
     @Column(name = "usr_role")
     private RoleType role;
 
-    // 기타 회원 정보
+    // ======= 기타 회원 정보 ======== //
     @Column(name = "usr_nickname", unique = true)
     private String nickName;
 
     @Column(name = "usr_job")
     private int job;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    private List<Integer> interests = new ArrayList<>();
+    @Column(name = "usr_intersts")
+    private String interests;
 
+    /**
+     * 권한 설정
+     **/
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(getRole().name()));
+        return authorities;
     }
 
     @Override
     public String getUsername() {
-        return String.valueOf(this.id);
+        return this.email;
     }
 
     @Override

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -8,8 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Getter
@@ -42,6 +40,6 @@ public class User {
     @Column(name = "usr_job")
     private int job;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    private List<Integer> interests = new ArrayList<>();
+//    @ElementCollection(fetch = FetchType.LAZY)
+//    private List<Integer> interests = new ArrayList<>();
 }

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -39,9 +39,6 @@ public class User {
     @Column(name = "usr_nickname", unique = true)
     private String nickName;
 
-    @Column(name = "usr_age")
-    private int age;
-
     @Column(name = "usr_job")
     private int job;
 

--- a/src/main/java/com/example/betteriter/user/domain/User.java
+++ b/src/main/java/com/example/betteriter/user/domain/User.java
@@ -79,4 +79,8 @@ public class User implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/example/betteriter/user/dto/JoinDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/JoinDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.*;
-import java.util.List;
 
 @Getter
 @Setter
@@ -30,8 +29,8 @@ public class JoinDto {
     @NotNull(message = "직업을 선택해야 합니다.")
     private int job;
 
-    @Size(min = 1, max = 3, message = "관심사는 1개이상 3개 이하여야 합니다.")
-    private List<Integer> interest;
+    @NotBlank(message = "올바른 관심사 입력 형식이 아닙니다.")
+    private String interests;
 
     public User toEntity(String encryptPassword) {
         return User.builder()
@@ -39,7 +38,8 @@ public class JoinDto {
                 .password(encryptPassword)
                 .nickName(nickName)
                 .job(job)
-                .interests(interest)
+                .role(RoleType.ROLE_USER)
+                .interests(interests)
                 .build();
     }
 }

--- a/src/main/java/com/example/betteriter/user/dto/JoinDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/JoinDto.java
@@ -13,8 +13,6 @@ import javax.validation.constraints.*;
 @Builder
 @AllArgsConstructor
 public class JoinDto {
-
-
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 

--- a/src/main/java/com/example/betteriter/user/dto/JoinDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/JoinDto.java
@@ -1,0 +1,45 @@
+package com.example.betteriter.user.dto;
+
+import com.example.betteriter.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.*;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class JoinDto {
+
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,20}$",
+            message = "비밀번호는 영어/숫자/특수문자를 포함해야합니다.")
+    private String password;
+
+    @NotBlank(message = "올바른 닉네임 형식이 아닙니다.")
+    private String nickName;
+
+    @NotNull(message = "직업을 선택해야 합니다.")
+    private int job;
+
+    @Size(min = 1, max = 3, message = "관심사는 1개이상 3개 이하여야 합니다.")
+    private List<Integer> interest;
+
+    public User toEntity(String encryptPassword) {
+        return User.builder()
+                .email(email)
+                .password(encryptPassword)
+                .nickName(nickName)
+                .job(job)
+                .interests(interest)
+                .build();
+    }
+}

--- a/src/main/java/com/example/betteriter/user/dto/LoginDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/LoginDto.java
@@ -1,0 +1,24 @@
+package com.example.betteriter.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class LoginDto {
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,20}$",
+            message = "비밀번호는 영어/숫자/특수문자를 포함해야합니다."
+    )
+    private String password;
+}

--- a/src/main/java/com/example/betteriter/user/dto/PasswordResetRequestDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/PasswordResetRequestDto.java
@@ -1,0 +1,23 @@
+package com.example.betteriter.user.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordResetRequestDto {
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,20}$",
+            message = "비밀번호는 영어/숫자/특수문자를 포함해야합니다."
+    )
+    private String password;
+}

--- a/src/main/java/com/example/betteriter/user/dto/UserServiceTokenResponseDto.java
+++ b/src/main/java/com/example/betteriter/user/dto/UserServiceTokenResponseDto.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 @Builder
 @AllArgsConstructor
-public class UserOauthLoginResponseDto {
+public class UserServiceTokenResponseDto {
     private String accessToken;
     private String refreshToken;
     private String expiredTime;

--- a/src/main/java/com/example/betteriter/user/repository/UserRepository.java
+++ b/src/main/java/com/example/betteriter/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthId(String oauthId);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/betteriter/user/service/AuthService.java
+++ b/src/main/java/com/example/betteriter/user/service/AuthService.java
@@ -1,0 +1,161 @@
+package com.example.betteriter.user.service;
+
+import com.example.betteriter.global.config.security.UserAuthentication;
+import com.example.betteriter.global.util.JwtUtil;
+import com.example.betteriter.global.util.RedisUtil;
+import com.example.betteriter.global.util.SecurityUtil;
+import com.example.betteriter.infra.EmailAuthenticationDto;
+import com.example.betteriter.infra.EmailDto;
+import com.example.betteriter.infra.EmailService;
+import com.example.betteriter.user.domain.User;
+import com.example.betteriter.user.dto.JoinDto;
+import com.example.betteriter.user.dto.LoginDto;
+import com.example.betteriter.user.dto.PasswordResetRequestDto;
+import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
+import com.example.betteriter.user.repository.UserRepository;
+import com.example.betteriter.user.util.PasswordUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final PasswordUtil passwordUtil;
+    private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
+    private final EmailService emailService;
+
+    @Override
+    public User loadUserByUsername(String userEmail) throws UsernameNotFoundException {
+        return this.userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
+    }
+
+    /* 회원 가입 */
+    @Transactional
+    public Long join(JoinDto joinDto) {
+        String encryptPassword = this.passwordUtil.encode(joinDto.getPassword());
+        return this.userRepository.save(joinDto.toEntity(encryptPassword)).getId();
+    }
+
+    /* 이메일 인증 요청 */
+    @Transactional
+    public void requestEmailForJoin(EmailDto emailDto) {
+        this.checkEmailDuplication(emailDto.getEmail());
+        String authCode = makeAuthCodeAndSave(emailDto);
+        this.emailService.sendEmailForJoin(emailDto.getEmail(), authCode);
+    }
+
+
+    /* 로그인 */
+    @Transactional
+    public UserServiceTokenResponseDto login(LoginDto loginRequestDto) {
+        User user = this.loadUserByUsername(loginRequestDto.getEmail());
+        if (!this.passwordUtil.isEqual(loginRequestDto.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // -> 여기서 SecurityContext 에 저장된 UserAuthentication 존재 x
+        UserAuthentication userAuthentication = new UserAuthentication(user);
+        SecurityContextHolder.getContext().setAuthentication(userAuthentication);
+        UserServiceTokenResponseDto serviceToken = jwtUtil.getServiceToken(user);
+
+        System.out.println(SecurityUtil.getCurrentUserEmail());
+        this.redisUtil.setData(String.valueOf(user.getId()), serviceToken.getRefreshToken()); // 토큰 발급 후 Redis 에 Refresh token 저장
+        return serviceToken;
+    }
+
+    /* 비밀번호 재설정 이메일 요청 */
+    @Transactional
+    public void requestEmailForPassword(EmailDto emailDto) {
+        // 해당 이메일 유저 존재 여부 확인 및 로그인 타입 확인
+        this.checkEmailExistenceAndType(emailDto.getEmail());
+        String authCode = makeAuthCodeAndSave(emailDto);
+        this.emailService.sendEmailForResetPassword(emailDto.getEmail(), authCode);
+    }
+
+    /* 비밀번호 재설정 */
+    @Transactional
+    public void resetPassword(PasswordResetRequestDto request) {
+        User user = checkEmailExistenceAndType(request.getEmail());
+        user.setPassword(this.passwordUtil.encode(request.getPassword()));
+        log.info(this.passwordUtil.encode(request.getPassword()));
+    }
+
+    /* 인증 코드 체크 */
+    @Transactional
+    public void verifyAuthCode(EmailAuthenticationDto emailAuthenticationDto) {
+        // 1.요청받은 인증코드와 Redis 저장된 인증코드 비교
+        String authCode = this.redisUtil.getData(emailAuthenticationDto.getEmail());
+        if (authCode == null) {
+            log.debug("AuthService.verifyAuthCode() Exception Occurs!");
+            throw new RuntimeException("인증 코드의 유효기간이 이미 지났습니다.");
+        }
+        if (!String.valueOf(emailAuthenticationDto.getCode()).equals(authCode)) {
+            log.debug("AuthService.verifyAuthCode() Exception Occurs!");
+            throw new RuntimeException("요청 받은 인증 코드의 검증이 실패했습니다.");
+        }
+        // 2.인증 코드 검증 성공(redis 데이터 삭제)
+        this.redisUtil.deleteData(emailAuthenticationDto.getEmail());
+    }
+
+
+    // ================================================================================ //
+
+    /* 인가 코드 생성 및 Redis 저장 */
+    private String makeAuthCodeAndSave(EmailDto emailDto) {
+        String authCode = this.createAuthCode();
+        // 해당 이메일을 키로 가지는 Redis 데이터가 존재하는 경우
+        if (this.redisUtil.getData(emailDto.getEmail()) != null) {
+            throw new RuntimeException("해당 이메일의 인증 코드가 이미 존재합니다.");
+        }
+        this.redisUtil.setDataExpire(emailDto.getEmail(), authCode, 60L * 3); // 3분
+        return authCode;
+    }
+
+    private void checkEmailDuplication(String email) {
+        if (this.userRepository.findByEmail(email).isPresent()) {
+            throw new RuntimeException("이미 존재하는 회원 이메일 입니다.");
+        }
+    }
+
+    private User checkEmailExistenceAndType(String email) {
+        // 해당 유저가 있는지 확인
+        User user = this.userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("해당 이메일 정보를 가진 유저 정보가 존재하지 않습니다."));
+        // 해당 유저의 회원가입 타입이 일반 회원가입인지 확인
+        if (null != user.getOauthId()) {
+            throw new RuntimeException("해당 유저는 카카오 로그인 유저 입니다.");
+        }
+        return user;
+    }
+
+    // 이메일 인증 시 랜덤 문자열 생성
+    private String createAuthCode() {
+        int length = 6;
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < length; i++) {
+                builder.append(random.nextInt(10));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            log.debug("UserService.createCode() exception occurs");
+            throw new RuntimeException("이메일 인증 코드 생성 중 예외가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
+++ b/src/main/java/com/example/betteriter/user/service/KakaoOauthService.java
@@ -57,7 +57,8 @@ public class KakaoOauthService {
      * - https://kauth.kakao.com/oauth/token
      * - application/x-www-form-urlencoded
      **/
-    private KakaoToken getKakaoToken(String code, ClientRegistration kakaoClientRegistration) {
+    private KakaoToken getKakaoToken(String code,
+                                     ClientRegistration kakaoClientRegistration) {
         return WebClient.create()
                 .post()
                 .uri(kakaoClientRegistration.getProviderDetails().getTokenUri())

--- a/src/main/java/com/example/betteriter/user/service/UserService.java
+++ b/src/main/java/com/example/betteriter/user/service/UserService.java
@@ -1,0 +1,59 @@
+package com.example.betteriter.user.service;
+
+import com.example.betteriter.global.config.properties.JwtProperties;
+import com.example.betteriter.global.config.security.UserAuthentication;
+import com.example.betteriter.global.util.JwtUtil;
+import com.example.betteriter.user.domain.User;
+import com.example.betteriter.user.dto.JoinDto;
+import com.example.betteriter.user.dto.LoginDto;
+import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
+import com.example.betteriter.user.repository.UserRepository;
+import com.example.betteriter.user.util.PasswordUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * - 유저 관련 로직을 담고 있는 서비스
+ * - 일반 회원가입, 로그인, 이메일 전송, 회원 탈퇴, 로그아웃 등
+ **/
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserService implements UserDetailsService {
+    private final UserRepository userRepository;
+    private final PasswordUtil passwordUtil;
+    private final JwtProperties jwtProperties;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public User loadUserByUsername(String userEmail) throws UsernameNotFoundException {
+        return this.userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
+    }
+
+    /* 회원 가입 */
+    @Transactional
+    public Long join(JoinDto joinDto) {
+        String encryptPassword = this.passwordUtil.encode(joinDto.getPassword());
+        return this.userRepository.save(joinDto.toEntity(encryptPassword)).getId();
+    }
+
+    /* 로그인 */
+    @Transactional
+    public UserServiceTokenResponseDto login(LoginDto loginRequestDto) {
+        User user = this.loadUserByUsername(loginRequestDto.getEmail());
+
+        if (!this.passwordUtil.isEqual(loginRequestDto.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+        UserAuthentication userAuthentication = new UserAuthentication(user);
+        SecurityContextHolder.getContext().setAuthentication(userAuthentication);
+        return this.jwtUtil.getServiceToken(user);
+    }
+}

--- a/src/main/java/com/example/betteriter/user/service/UserService.java
+++ b/src/main/java/com/example/betteriter/user/service/UserService.java
@@ -1,74 +1,26 @@
 package com.example.betteriter.user.service;
 
-import com.example.betteriter.global.config.security.UserAuthentication;
-import com.example.betteriter.global.util.JwtUtil;
 import com.example.betteriter.global.util.RedisUtil;
 import com.example.betteriter.global.util.SecurityUtil;
 import com.example.betteriter.user.domain.User;
-import com.example.betteriter.user.dto.EmailDto;
-import com.example.betteriter.user.dto.JoinDto;
-import com.example.betteriter.user.dto.LoginDto;
-import com.example.betteriter.user.dto.UserServiceTokenResponseDto;
 import com.example.betteriter.user.repository.UserRepository;
-import com.example.betteriter.user.util.PasswordUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * - 유저 관련 로직을 담고 있는 서비스
- * - 일반 회원가입, 로그인, 이메일 전송, 회원 탈퇴, 로그아웃 등
+ * - 회원 탈퇴, 로그아웃, 회원 정보 수정 등
  **/
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class UserService implements UserDetailsService {
+public class UserService {
     private final UserRepository userRepository;
-    private final PasswordUtil passwordUtil;
-    private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
-    private final EmailService emailService;
 
-    @Override
-    public User loadUserByUsername(String userEmail) throws UsernameNotFoundException {
-        return this.userRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
-    }
-
-    /* 회원 가입 */
-    @Transactional
-    public Long join(JoinDto joinDto) {
-        String encryptPassword = this.passwordUtil.encode(joinDto.getPassword());
-        return this.userRepository.save(joinDto.toEntity(encryptPassword)).getId();
-    }
-
-    /* 이메일 인증 */
-    public void email(EmailDto emailDto) {
-
-    }
-
-
-    /* 로그인 */
-    @Transactional
-    public UserServiceTokenResponseDto login(LoginDto loginRequestDto) {
-        User user = this.loadUserByUsername(loginRequestDto.getEmail());
-        if (!this.passwordUtil.isEqual(loginRequestDto.getPassword(), user.getPassword())) {
-            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
-        }
-
-        // -> 여기서 SecurityContext 에 저장된 UserAuthentication 존재 x
-        UserAuthentication userAuthentication = new UserAuthentication(user);
-        SecurityContextHolder.getContext().setAuthentication(userAuthentication);
-        UserServiceTokenResponseDto serviceToken = jwtUtil.getServiceToken(user);
-
-        this.redisUtil.setData(String.valueOf(user.getId()), serviceToken.getRefreshToken()); // 토큰 발급 후 Redis 에 Refresh token 저장
-        return serviceToken;
-    }
 
     /* 로그아웃 */
     @Transactional
@@ -89,8 +41,4 @@ public class UserService implements UserDetailsService {
         return this.userRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
                 .orElseThrow(() -> new UsernameNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
     }
-
-
-    // 이메일 인증 시 랜덤 문자열 생성
-
 }

--- a/src/main/java/com/example/betteriter/user/util/PasswordUtil.java
+++ b/src/main/java/com/example/betteriter/user/util/PasswordUtil.java
@@ -1,0 +1,26 @@
+package com.example.betteriter.user.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PasswordUtil {
+    public static final String PASSWORD_PATTERN = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,20}$";
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public PasswordUtil(BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    /* 암호화 */
+    public String encode(String password) {
+        return bCryptPasswordEncoder.encode(password);
+    }
+
+    /* 비밀번호 동일성 체크 */
+    public boolean isEqual(String password, String encodedPassword) {
+        return bCryptPasswordEncoder.matches(password, encodedPassword);
+    }
+}

--- a/src/main/java/com/example/betteriter/user/util/PasswordUtil.java
+++ b/src/main/java/com/example/betteriter/user/util/PasswordUtil.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class PasswordUtil {
-    public static final String PASSWORD_PATTERN = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,20}$";
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public PasswordUtil(BCryptPasswordEncoder bCryptPasswordEncoder) {
@@ -20,7 +19,7 @@ public class PasswordUtil {
     }
 
     /* 비밀번호 동일성 체크 */
-    public boolean isEqual(String password, String encodedPassword) {
-        return bCryptPasswordEncoder.matches(password, encodedPassword);
+    public boolean isEqual(String inputPassword, String encodedPassword) {
+        return bCryptPasswordEncoder.matches(inputPassword, encodedPassword);
     }
 }

--- a/src/main/java/com/example/betteriter/user/util/PasswordUtil.java
+++ b/src/main/java/com/example/betteriter/user/util/PasswordUtil.java
@@ -1,17 +1,15 @@
 package com.example.betteriter.user.util;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class PasswordUtil {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-
-    public PasswordUtil(BCryptPasswordEncoder bCryptPasswordEncoder) {
-        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
-    }
 
     /* 암호화 */
     public String encode(String password) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,24 @@ spring:
     port: ${REDIS_PORT:6379}
     password: ${REDIS_PASSWORD}
 
+  ### mail
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD:password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+      auth-code-expiration-millis: 1800000 # 30 * 60 mills (인증 코드 만료 기간)
+      
 ### JWT
 jwt:
   bearer: ${JWT_BEARER:Bearer}
@@ -60,7 +78,6 @@ jwt:
   access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token 헤더
   refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1일
   refresh-header: ${JWT_REFRESH_HEADER:Authorization-refresh} # Refresh Token 헤더
-
 
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
   ## JPA
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
     properties:
       hibernate:

--- a/src/test/java/com/example/betteriter/user/domain/UserTest.java
+++ b/src/test/java/com/example/betteriter/user/domain/UserTest.java
@@ -1,0 +1,26 @@
+package com.example.betteriter.user.domain;
+
+
+import com.example.betteriter.user.dto.RoleType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserTest {
+
+    @Test
+    @DisplayName("user test")
+    public void userTest() {
+        User user = User.builder()
+                .id(1L)
+                .nickName("닉네임")
+                .email("danaver12@daum.net")
+                .password("1234")
+                .role(RoleType.ROLE_USER)
+                .build();
+
+        System.out.println(user.getRole().name());
+        assertThat(user.getRole().name()).isEqualTo("ROLE_USER");
+    }
+}


### PR DESCRIPTION
### PR 제목

- 회언 인증 기능(이메일 인증, 비밀번호 재설정) 등 기능 구현 및 회원 일반 기능(로그아웃,회원탈퇴) 구현

### PR 생성 날짜

- 2023/09/30

### PR 내용

- 1. 회원 인증 로직과 회원 일반 로직 분리 (User 와 Auth)
- 2. `일반 회원가입`, `일반 로그인`, `이메일 인증`, `비밀번호 재설정`, `회원 탈퇴`, `로그 아웃` 기능 구현 및 테스트 완료
- 3. Redis 기능 추가(인증 코드 담는 용도)
- 4. Gmail SMTP 등록 및 이메일 인증 테스트 완료

### 첨부 자료
![](https://velog.velcdn.com/images/choidongkuen/post/323fc226-1847-45f7-84f7-691262ec2f69/image.png)

=> 이메일 형식 예시 (피그마와 약간 차이가 있어 다음 회의 때 건의 예정)

### 관련 이슈

- close #19 