### PR TITLE
[FEATURE-34] application.yml 프로파일 별로 분할 및 access token 재발급 API 보완

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -35,15 +35,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      #      - name: set yaml secret
-      #        uses: microsoft/variable-substitution@v1
-      #        with:
-      #          files: ./src/main/resources/application.yml
-      #        env:
-      #          spring.datasource.url: ${{ secrets.DATABASE_URL }}
-      #          spring.datasource.username: ${{ secrets.DATABASE_USERNAME }}
-      #          spring.datasource.password: ${{ secrets.DATABASE_PASSWORD }}
-
       - name: Grant execute Permission for gradlew
         run: chmod +x gradlew
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","-Duser.timezone=Asia/Seoul", "/app.jar"]
+ENTRYPOINT ["java","-jar","-Dspring.profiles.active=prod","-Duser.timezone=Asia/Seoul", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.15'
@@ -19,7 +18,7 @@ asciidoctor {
 
 bootJar {
     dependsOn asciidoctor
-    from ("${asciidoctor.outputDir}/html5") {
+    from("${asciidoctor.outputDir}/html5") {
         into 'static/docs'
     }
 }
@@ -57,13 +56,12 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    
+
     implementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     implementation 'org.mockito:mockito-core:5.4.0'
     implementation 'org.mockito:mockito-junit-jupiter:5.4.0'
     implementation 'org.junit.platform:junit-platform-runner:1.10.0'
     implementation 'org.junit.vintage:junit-vintage-engine:5.10.0'
-
 
     // document
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'

--- a/src/main/java/com/example/betteriter/fo_domain/user/dto/ReissueTokenResponseDto.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/dto/ReissueTokenResponseDto.java
@@ -1,7 +1,6 @@
 package com.example.betteriter.fo_domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,19 +8,13 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-
-/**
- * - oauth 로그인 후 응답 객체
- **/
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
-public class UserServiceTokenResponseDto {
+public class ReissueTokenResponseDto {
     private String accessToken;
     private String refreshToken;
     @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
     private LocalDateTime expiredTime;
-    @JsonProperty("isExisted")
-    private boolean isExisted;
 }

--- a/src/main/java/com/example/betteriter/fo_domain/user/service/AuthService.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/service/AuthService.java
@@ -1,18 +1,18 @@
 package com.example.betteriter.fo_domain.user.service;
 
+import com.example.betteriter.fo_domain.user.domain.User;
+import com.example.betteriter.fo_domain.user.dto.JoinDto;
+import com.example.betteriter.fo_domain.user.dto.LoginDto;
+import com.example.betteriter.fo_domain.user.dto.PasswordResetRequestDto;
+import com.example.betteriter.fo_domain.user.dto.UserServiceTokenResponseDto;
 import com.example.betteriter.fo_domain.user.repository.UserRepository;
+import com.example.betteriter.fo_domain.user.util.PasswordUtil;
 import com.example.betteriter.global.config.security.UserAuthentication;
 import com.example.betteriter.global.util.JwtUtil;
 import com.example.betteriter.global.util.RedisUtil;
 import com.example.betteriter.infra.EmailAuthenticationDto;
 import com.example.betteriter.infra.EmailDto;
 import com.example.betteriter.infra.EmailService;
-import com.example.betteriter.fo_domain.user.domain.User;
-import com.example.betteriter.fo_domain.user.dto.JoinDto;
-import com.example.betteriter.fo_domain.user.dto.LoginDto;
-import com.example.betteriter.fo_domain.user.dto.PasswordResetRequestDto;
-import com.example.betteriter.fo_domain.user.dto.UserServiceTokenResponseDto;
-import com.example.betteriter.fo_domain.user.util.PasswordUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -64,7 +64,7 @@ public class AuthService implements UserDetailsService {
         if (!this.passwordUtil.isEqual(loginRequestDto.getPassword(), user.getPassword())) {
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
-        return saveAuthenticationAndReturnToken(user);
+        return this.saveAuthenticationAndReturnToken(user);
     }
 
 

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -52,8 +52,11 @@ public class SecurityConfig {
                 .antMatchers("/login/callback/**").permitAll()
                 // 특정 URI 예외 처리
                 // antMatchers().permitAll() 을 통해 특정 API 요청은
-                // jwtAuthenticationFilter 에 걸려도 ExceptionTranslationFilter 을 거치지 않는다 x
-                .antMatchers("/login/callback/**", "/auth/**", "/temp/**", "/test/**").permitAll()
+                // jwtAuthenticationFilter 에 걸려도 ExceptionTranslationFilter 을 거치지 않는다 x (무시 x -> 일단 인증 필터를 거치긴 함 !!)
+                .antMatchers("/login/callback/**",
+                        "/auth/**", "/temp/**",
+                        "/test/**", "/reissue")
+                .permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/example/betteriter/global/util/JwtUtil.java
+++ b/src/main/java/com/example/betteriter/global/util/JwtUtil.java
@@ -1,8 +1,8 @@
 package com.example.betteriter.global.util;
 
-import com.example.betteriter.global.config.properties.JwtProperties;
 import com.example.betteriter.fo_domain.user.domain.User;
 import com.example.betteriter.fo_domain.user.dto.UserServiceTokenResponseDto;
+import com.example.betteriter.global.config.properties.JwtProperties;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +11,6 @@ import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -72,12 +71,11 @@ public class JwtUtil {
         String accessToken = this.createAccessToken(String.valueOf(user.getId()));
         String refreshToken = this.createRefreshToken();
 
-        LocalDateTime expireTime = LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000);
         this.redisUtil.setData(String.valueOf(user.getId()), refreshToken);
         return UserServiceTokenResponseDto.builder()
                 .accessToken(this.jwtProperties.getBearer() + " " + accessToken)
                 .refreshToken(refreshToken)
-                .expiredTime(expireTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .expiredTime(LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000))
                 .isExisted(user.getNickName() != null)
                 .build();
     }

--- a/src/main/resources/application-auth.yml
+++ b/src/main/resources/application-auth.yml
@@ -1,0 +1,32 @@
+## auth(인증)
+spring:
+  config:
+    activate:
+      on-profile: "auth"
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            scope:
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+## JWT
+jwt:
+  bearer: ${JWT_BEARER:Bearer}
+  secret: ${JWT_SECRET_KEY}
+  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1시간
+  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token 헤더
+  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1일
+  refresh-header: ${JWT_REFRESH_HEADER:Authorization-refresh} # Refresh Token 헤더

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,12 @@
+## Database
+spring:
+  config:
+    activate:
+      on-profile: "datasource"
+
+  datasource:
+    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT}/${DATABASE_NAME:iter}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,23 @@
+## dev(개발) env
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        default_batch_fetch_size: 100
+
+## 개발 환경 = debug
+logging:
+  level:
+    org.hibernate.sql: debug
+    org.hibernate.type: debug
+

--- a/src/main/resources/application-mail.yml
+++ b/src/main/resources/application-mail.yml
@@ -1,0 +1,22 @@
+## mail
+spring:
+  config:
+    activate:
+      on-profile: "mail"
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD:password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+      auth-code-expiration-millis: 1800000 # 30 * 60 mills (인증 코드 만료 기간)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+## prod(운영) env
+spring:
+  config:
+    activate:
+      on-profile: "prod"
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        show_sql: true
+        default_batch_fetch_size: 100
+
+## 운영 환경 = info
+logging:
+  level:
+    org.hibernate.sql: info
+    org.hibernate.type: info

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,10 @@
+## Redis
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+
+  redis:
+    host: ${REDIS_HOST:localhost}
+    port: ${REDIS_PORT:6379}
+    password: ${REDIS_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,82 +5,87 @@ spring:
   application:
     name: Better-Iter Application
 
-  mvc:
-    pathmatch:
-      matching-strategy: ant_path_matcher
+  profiles:
+    group:
+      "dev": "dev, auth, datasource, mail, redis" # 개발 환경 프로파일
+      "prod": "prod, auth, datasource, mail, redis" # 운영 환경 프로파일
 
-  ## Database
-  datasource:
-    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT}/${DATABASE_NAME:iter}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
-  ## JPA
-  jpa:
-    hibernate:
-      ddl-auto: create
-
-    properties:
-      hibernate:
-        show_sql: true
-        default_batch_fetch_size: 100
-
-  ## Oauth
-  security:
-    oauth2:
-      client:
-        registration:
-          kakao:
-            client-id: ${KAKAO_CLIENT_ID}
-            client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URI}
-            client-authentication-method: POST
-            authorization-grant-type: authorization_code
-            scope:
-              - account_email
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
-
-  ### REDIS
-  redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
-    password: ${REDIS_PASSWORD}
-
-  ### mail
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${EMAIL_USERNAME}
-    password: ${EMAIL_PASSWORD:password}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-            required: true
-          connectiontimeout: 5000
-          timeout: 5000
-          writetimeout: 5000
-      auth-code-expiration-millis: 1800000 # 30 * 60 mills (인증 코드 만료 기간)
-
-### JWT
-jwt:
-  bearer: ${JWT_BEARER:Bearer}
-  secret: ${JWT_SECRET_KEY}
-  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1시간
-  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token 헤더
-  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1일
-  refresh-header: ${JWT_REFRESH_HEADER:Authorization-refresh} # Refresh Token 헤더
-
-
-logging:
-  level:
-    org.hibernate.sql: debug
-    org.hibernate.type: trace
+#  mvc:
+#    pathmatch:
+#      matching-strategy: ant_path_matcher
+#
+#  ## Database
+#  datasource:
+#    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT}/${DATABASE_NAME:iter}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+#    username: ${DATABASE_USERNAME}
+#    password: ${DATABASE_PASSWORD}
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+#
+#  ## JPA
+#  jpa:
+#    hibernate:
+#      ddl-auto: create
+#
+#    properties:
+#      hibernate:
+#        show_sql: true
+#        default_batch_fetch_size: 100
+#
+#  ## Oauth
+#  security:
+#    oauth2:
+#      client:
+#        registration:
+#          kakao:
+#            client-id: ${KAKAO_CLIENT_ID}
+#            client-secret: ${KAKAO_CLIENT_SECRET}
+#            redirect-uri: ${KAKAO_REDIRECT_URI}
+#            client-authentication-method: POST
+#            authorization-grant-type: authorization_code
+#            scope:
+#              - account_email
+#        provider:
+#          kakao:
+#            authorization-uri: https://kauth.kakao.com/oauth/authorize
+#            token-uri: https://kauth.kakao.com/oauth/token
+#            user-info-uri: https://kapi.kakao.com/v2/user/me
+#            user-name-attribute: id
+#
+#  ### REDIS
+#  redis:
+#    host: ${REDIS_HOST:localhost}
+#    port: ${REDIS_PORT:6379}
+#    password: ${REDIS_PASSWORD}
+#
+#  ### mail
+#  mail:
+#    host: smtp.gmail.com
+#    port: 587
+#    username: ${EMAIL_USERNAME}
+#    password: ${EMAIL_PASSWORD:password}
+#    properties:
+#      mail:
+#        smtp:
+#          auth: true
+#          starttls:
+#            enable: true
+#            required: true
+#          connectiontimeout: 5000
+#          timeout: 5000
+#          writetimeout: 5000
+#      auth-code-expiration-millis: 1800000 # 30 * 60 mills (인증 코드 만료 기간)
+#
+#### JWT
+#jwt:
+#  bearer: ${JWT_BEARER:Bearer}
+#  secret: ${JWT_SECRET_KEY}
+#  access-expiration: ${JWT_ACCESS_EXPIRE:3600000} # 1시간
+#  access-header: ${JWT_ACCESS_HEADER:Authorization} # Access Token 헤더
+#  refresh-expiration: ${JWT_REFRESH_EXPIRE:86400000} # 1일
+#  refresh-header: ${JWT_REFRESH_HEADER:Authorization-refresh} # Refresh Token 헤더
+#
+#
+#logging:
+#  level:
+#    org.hibernate.sql: debug
+#    org.hibernate.type: trace


### PR DESCRIPTION
### PR 제목

- application.yml 을 `prod` 와 `dev` 로 분할 및 access token 재발급 부분 코드 보완 및 추가 구현

### PR 생성 날짜

- 2023/10/11

### PR 내용

- application.yml 을 `application-datasource.yml`, `application-dev.yml` , `application-prod.yml`, `application-mail.yml`,`application-auth.yml` ,`application-redis.yml` 로 분할 및 그룹화
- 이에 따른 Dockerfile 수정
- `access token 재발급 API 코드 추가 구현 및 리팩토링` # RTR 방법 진행 (밑에 참고해주세요)

### 첨부 자료

- [[[JWT] Access Token과 Refresh Token 그리고 RTR 기법에 대해서 알아보자.](https://seungyong20.tistory.com/entry/JWT-Access-Token%EA%B3%BC-Refresh-Token-%EA%B7%B8%EB%A6%AC%EA%B3%A0-RTR-%EA%B8%B0%EB%B2%95%EC%97%90-%EB%8C%80%ED%95%B4%EC%84%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90)](https://seungyong20.tistory.com/entry/JWT-Access-Token%EA%B3%BC-Refresh-Token-%EA%B7%B8%EB%A6%AC%EA%B3%A0-RTR-%EA%B8%B0%EB%B2%95%EC%97%90-%EB%8C%80%ED%95%B4%EC%84%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90)

### 관련 이슈

- close #34 