### PR TITLE
[FEATURE-80] SpringDoc openAPI Swagger 재설정 및 swagger 어노테이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,6 @@ dependencies {
 
     // document
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
-    implementation 'io.springfox:springfox-swagger2:2.9.2'
-    implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/betteriter/bo_domain/home/controller/HomeController.java
+++ b/src/main/java/com/example/betteriter/bo_domain/home/controller/HomeController.java
@@ -2,6 +2,7 @@ package com.example.betteriter.bo_domain.home.controller;
 
 import com.example.betteriter.bo_domain.home.dto.GetHomeResponseDto;
 import com.example.betteriter.bo_domain.home.service.HomeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "HomeController", description = "Home API")
 @Slf4j
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/example/betteriter/bo_domain/news/controller/NewsController.java
+++ b/src/main/java/com/example/betteriter/bo_domain/news/controller/NewsController.java
@@ -7,6 +7,7 @@ import com.example.betteriter.bo_domain.news.exception.NewsHandler;
 import com.example.betteriter.bo_domain.news.service.NewsService;
 import com.example.betteriter.global.common.response.ResponseDto;
 import com.example.betteriter.global.error.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
@@ -17,6 +18,7 @@ import javax.validation.Valid;
 import java.util.List;
 
 
+@Tag(name = "NewsController", description = "News API")
 @Slf4j
 @RequestMapping("/news")
 @RequiredArgsConstructor

--- a/src/main/java/com/example/betteriter/bo_domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/betteriter/bo_domain/quiz/controller/QuizController.java
@@ -1,12 +1,14 @@
 package com.example.betteriter.bo_domain.quiz.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "QuizController", description = "Quiz API")
 @Slf4j
-@RequestMapping("/manufacturer")
+@RequestMapping("/quiz")
 @RequiredArgsConstructor
 @RestController
 public class QuizController {

--- a/src/main/java/com/example/betteriter/fo_domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/comment/controller/CommentController.java
@@ -1,12 +1,14 @@
 package com.example.betteriter.fo_domain.comment.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "CommentController", description = "Comment API")
 @Slf4j
-@RequestMapping("/follow")
+@RequestMapping("/comment")
 @RequiredArgsConstructor
 @RestController
 public class CommentController {

--- a/src/main/java/com/example/betteriter/fo_domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.example.betteriter.fo_domain.review.dto.CreateReviewRequestDto;
 import com.example.betteriter.fo_domain.review.exception.ReviewHandler;
 import com.example.betteriter.fo_domain.review.service.ReviewService;
 import com.example.betteriter.global.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
@@ -17,6 +18,7 @@ import javax.validation.Valid;
 
 import static com.example.betteriter.global.error.exception.ErrorCode._METHOD_ARGUMENT_ERROR;
 
+@Tag(name = "ReviewController", description = "Review API")
 @Slf4j
 @RequestMapping("/review")
 @RequiredArgsConstructor

--- a/src/main/java/com/example/betteriter/fo_domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/search/controller/SearchController.java
@@ -1,12 +1,14 @@
 package com.example.betteriter.fo_domain.search.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "SearchController", description = "Search API")
 @Slf4j
-@RequestMapping("/category")
+@RequestMapping("/search")
 @RequiredArgsConstructor
 @RestController
 public class SearchController {

--- a/src/main/java/com/example/betteriter/fo_domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/controller/AuthController.java
@@ -9,6 +9,11 @@ import com.example.betteriter.fo_domain.user.service.AuthService;
 import com.example.betteriter.global.common.response.ResponseDto;
 import com.example.betteriter.infra.EmailAuthenticationDto;
 import com.example.betteriter.infra.EmailDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,6 +31,7 @@ import static com.example.betteriter.global.error.exception.ErrorCode._METHOD_AR
  **/
 
 @Slf4j
+@Tag(name = "AuthController", description = "Authentication API")
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 @RestController
@@ -39,7 +45,14 @@ public class AuthController {
      * - /auth/join
      **/
     @PostMapping("/join")
+    @Operation(summary = "일반 회원가입")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "SUCCESS_200", description = "일반 회원가입 성공"),
+            @ApiResponse(responseCode = "AUTH_EMAIL_DUPLICATION_401", description = "이메일 이미 존재"),
+            @ApiResponse(responseCode = "METHOD_ARGUMENT_ERROR", description = "올바르지 않은 클라이언트 요청값")}
+    )
     public ResponseDto<Long> join(
+            @Schema(description = "일반 회원가입 요청 객체")
             @RequestBody @Valid JoinDto request,
             BindingResult bindingResult
     ) {

--- a/src/main/java/com/example/betteriter/fo_domain/user/controller/KakaoOauthController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/controller/KakaoOauthController.java
@@ -4,6 +4,7 @@ import com.example.betteriter.fo_domain.user.dto.UserServiceTokenResponseDto;
 import com.example.betteriter.fo_domain.user.dto.oauth.KakaoJoinDto;
 import com.example.betteriter.fo_domain.user.service.KakaoOauthService;
 import com.example.betteriter.global.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.io.IOException;
 
+@Tag(name = "KakaoOauthController", description = "Kakao Oauth API")
 @Slf4j
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/example/betteriter/fo_domain/user/controller/UserController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.betteriter.fo_domain.user.controller;
 
 import com.example.betteriter.fo_domain.user.service.UserService;
 import com.example.betteriter.global.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 1. 카카오 oauth 로그인 시 처음 회원 인지 반환
  * 2. 회원가입 후 관심 분야 반환 해야 하나?
  **/
-
+@Tag(name = "UserController", description = "User API")
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/user")

--- a/src/main/java/com/example/betteriter/global/config/docs/SwaggerConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/docs/SwaggerConfig.java
@@ -18,6 +18,7 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+
         Info info = new Info()
                 .title("better-iter")
                 .description("better-iter API 명세서")

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig {
         return web -> web.ignoring()
                 .antMatchers("/css/**", "/js/**",
                         "/img/**", "/error",
-                        "/favicon.ico", "/resources/**",
-                        "/swagger-ui/**", "/v3/api-docs/**"
+                        "/favicon.ico", "/resources/**"
+                        , "/swagger-ui/**", "/v3/api-docs/**"
                 );
     }
 
@@ -57,7 +57,8 @@ public class SecurityConfig {
                 // antMatchers().permitAll() 을 통해 특정 API 요청은
                 // jwtAuthenticationFilter 에 걸려도 ExceptionTranslationFilter 을 거치지 않는다 x (무시 x -> 일단 인증 필터를 거치긴 함 !!)
                 .antMatchers("/login/callback/**",
-                        "/auth/**", "/temp/**", "/reissue")
+                        "/auth/**", "/temp/**",
+                        "/reissue")
                 .permitAll()
                 .antMatchers("/news/**").hasRole("ADMIN")
                 .anyRequest().authenticated()

--- a/src/main/resources/application-docs.yml
+++ b/src/main/resources/application-docs.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: "docs"
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui/index.html
+    groups-order: desc
+    doc-expansion: none
+    tags-sorter: alpha
+    operations-sorter: method
+    disable-swagger-default-url: true
+    display-request-duration: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,5 +7,5 @@ spring:
 
   profiles:
     group:
-      "dev": "dev, auth, datasource, mail, redis" # 개발 환경 프로파일
-      "prod": "prod, auth, datasource, mail, redis" # 운영 환경 프로파일
+      "dev": "dev, auth, datasource, mail, redis, docs" # 개발 환경 프로파일
+      "prod": "prod, auth, datasource, mail, redis, docs" # 운영 환경 프로파일


### PR DESCRIPTION
### PR 제목

- api 자동 문서화를 위한 `Spring Doc Swagger` 을 적용합니다.

### PR 생성 날짜

- 2023/11/15

### PR 내용

- `Spring Doc Swagger` 의존성 추가
- Swagger  관련 설정
- 어노테이션 추가

### 첨부 자료

- [Swagger Doc OpenAPI](https://hogwart-scholars.tistory.com/entry/Spring-Boot-SpringDoc%EA%B3%BC-Swagger%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4-API-%EB%AC%B8%EC%84%9C%ED%99%94-%EC%9E%90%EB%8F%99%ED%99%94%ED%95%98%EA%B8%B0)

### 관련 이슈

- close #80 