### PR TITLE
[FEATURE-99] 인증 과정 응답 코드 세분화 및 회원 탈퇴 리팩토링

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -2,7 +2,7 @@ name: CI/CD Automation using github actions and Docker
 
 on:
   push:
-    branches: '*'
+    branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
 

--- a/src/main/java/com/example/betteriter/fo_domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/controller/AuthController.java
@@ -15,8 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
@@ -99,12 +97,12 @@ public class AuthController {
      * - /auth/login
      **/
     @PostMapping("/login")
-    public ResponseEntity<UserServiceTokenResponseDto> login(
+    public ResponseDto<UserServiceTokenResponseDto> login(
             @Valid @RequestBody LoginDto loginRequestDto,
             BindingResult bindingResult
     ) {
         this.checkRequestValidation(bindingResult);
-        return new ResponseEntity<>(this.authService.login(loginRequestDto), HttpStatus.OK);
+        return ResponseDto.onSuccess(this.authService.login(loginRequestDto));
     }
 
     /**

--- a/src/main/java/com/example/betteriter/fo_domain/user/controller/UserController.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/controller/UserController.java
@@ -38,9 +38,9 @@ public class UserController {
      * 1. 프론트에서 가지고 있는 Access Token 삭제
      * 2. User 정보 삭제
      **/
-    @DeleteMapping("/withdraw/{reasons}")
+    @DeleteMapping("/withdraw")
     public ResponseDto<Void> withdraw(
-            @PathVariable String reasons
+            @RequestParam String reasons
     ) {
         this.userService.withdraw(reasons);
         return ResponseDto.onSuccess(null);

--- a/src/main/java/com/example/betteriter/fo_domain/user/dto/JoinDto.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/dto/JoinDto.java
@@ -6,7 +6,6 @@ import com.example.betteriter.global.constant.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.validation.constraints.*;
 import java.util.Arrays;
@@ -16,7 +15,6 @@ import java.util.stream.Collectors;
 import static com.example.betteriter.global.constant.RoleType.ROLE_USER;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 public class JoinDto {

--- a/src/main/java/com/example/betteriter/fo_domain/user/exception/AccessTokenIsValidException.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/exception/AccessTokenIsValidException.java
@@ -1,0 +1,11 @@
+package com.example.betteriter.fo_domain.user.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class AccessTokenIsValidException extends AuthenticationException {
+    private final static String message = "AccessTokenIsValidException";
+
+    public AccessTokenIsValidException() {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/betteriter/fo_domain/user/exception/RefreshTokenIsNotMatchException.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/exception/RefreshTokenIsNotMatchException.java
@@ -1,0 +1,12 @@
+package com.example.betteriter.fo_domain.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenIsNotMatchException extends RuntimeException {
+    private final static String message = "RefreshTokenIsNotMatchException";
+
+    public RefreshTokenIsNotMatchException() {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/betteriter/fo_domain/user/exception/RefreshTokenIsNotValidException.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/exception/RefreshTokenIsNotValidException.java
@@ -1,0 +1,10 @@
+package com.example.betteriter.fo_domain.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenIsNotValidException extends RuntimeException {
+    public RefreshTokenIsNotValidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/betteriter/fo_domain/user/service/UserService.java
+++ b/src/main/java/com/example/betteriter/fo_domain/user/service/UserService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -45,16 +44,14 @@ public class UserService {
         Users users = this.getUserAndDeleteRefreshToken();
         SecurityUtil.clearSecurityContext(); // SecurityContext 초기화
         this.saveUsersWithdrawReason(reasons); // 유저 탈퇴 사유 저장 메소드
-        this.usersRepository.delete(users);
+        this.usersRepository.delete(users); // 유저 삭제
     }
 
     /* 회원 탈퇴 사유 저장 */
     private void saveUsersWithdrawReason(String reasons) {
-        List<Integer> reasonToInteger = Arrays.stream(reasons.split(","))
+        Arrays.stream(reasons.split(","))
                 .map(Integer::valueOf)
-                .collect(Collectors.toList());
-        
-        reasonToInteger.stream()
+                .collect(Collectors.toList()).stream()
                 .map(UsersWithdrawReason::new)
                 .forEach(this.usersWithdrawReasonRepository::save);
     }

--- a/src/main/java/com/example/betteriter/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/betteriter/global/common/code/status/ErrorStatus.java
@@ -38,7 +38,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // JWT Error
     _JWT_IS_NOT_EXIST(HttpStatus.UNAUTHORIZED, "JWT_IS_NOT_EXIST", "Authorization 헤더에 JWT 정보가 존재하지 않습니다."),
-    _JWT_IS_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT_IS_NOT_VALID", "JWT 가 유효하지 않습니다."),
+    _JWT_IS_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT_IS_NOT_VALID", "Access Token 이 유효하지 않습니다."),
+    _JWT_REFRESH_TOKEN_IS_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT_REFRESH_TOKEN_IS_NOT_VALID", "Refresh Token 이 유효하지 않습니다."),
+    _JWT_ACCESS_TOKEN_IS_VALID(HttpStatus.UNAUTHORIZED, "JWT_ACCESS_TOKEN_IS_VALID", "Access Token 이 유효합니다."),
+    _JWT_REFRESH_TOKEN_IS_NOT_MATCH(HttpStatus.UNAUTHORIZED, "JWT_REFRESH_TOKEN_IS_NOT_MATCH", "Refresh Token 이 일치하지 않습니다."),
 
     // Example (For Test)
     TEST_BAD_REQUEST(HttpStatus.BAD_REQUEST, "TEST_400_001", "잘못된 요청 입니다. (For Test)"),

--- a/src/main/java/com/example/betteriter/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/betteriter/global/common/code/status/ErrorStatus.java
@@ -30,12 +30,15 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Common Error & Global Error
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401", "인증 과정에서 오류가 발생했습니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_401", "인증 과정에서 오류가 발생했습니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "AUTHORIZATION_403", "금지된 요청입니다."),
     _METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_405", "지원하지 않는 Http Method 입니다."),
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러가 발생했습니다."),
-
     _METHOD_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "METHOD_ARGUMENT_ERROR", "올바르지 않은 클라이언트 요청값입니다."), // controller 에서 받은 요청 DTO 유효성 검증
+
+    // JWT Error
+    _JWT_IS_NOT_EXIST(HttpStatus.UNAUTHORIZED, "JWT_IS_NOT_EXIST", "Authorization 헤더에 JWT 정보가 존재하지 않습니다."),
+    _JWT_IS_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT_IS_NOT_VALID", "JWT 가 유효하지 않습니다."),
 
     // Example (For Test)
     TEST_BAD_REQUEST(HttpStatus.BAD_REQUEST, "TEST_400_001", "잘못된 요청 입니다. (For Test)"),

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -57,8 +57,7 @@ public class SecurityConfig {
                 // antMatchers().permitAll() 을 통해 특정 API 요청은
                 // jwtAuthenticationFilter 에 걸려도 ExceptionTranslationFilter 을 거치지 않는다 x (무시 x -> 일단 인증 필터를 거치긴 함 !!)
                 .antMatchers("/login/callback/**",
-                        "/auth/**", "/temp/**",
-                        "/reissue")
+                        "/auth/**", "/temp/**", "/reissue")
                 .permitAll()
                 .antMatchers("/news/**").hasRole("ADMIN")
                 .anyRequest().authenticated()

--- a/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/betteriter/global/config/security/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 // antMatchers().permitAll() 을 통해 특정 API 요청은
                 // jwtAuthenticationFilter 에 걸려도 ExceptionTranslationFilter 을 거치지 않는다 x (무시 x -> 일단 인증 필터를 거치긴 함 !!)
                 .antMatchers("/login/callback/**",
-                        "/auth/**", "/temp/**", "/reissue")
+                        "/auth/**", "/temp/**")
                 .permitAll()
                 .antMatchers("/news/**").hasRole("ADMIN")
                 .anyRequest().authenticated()

--- a/src/main/java/com/example/betteriter/global/filter/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/betteriter/global/filter/JwtAccessDeniedHandler.java
@@ -1,16 +1,15 @@
 package com.example.betteriter.global.filter;
 
-import com.example.betteriter.fo_domain.user.exception.ErrorMessage;
+import com.example.betteriter.global.common.code.status.ErrorStatus;
+import com.example.betteriter.global.common.response.ResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -23,38 +22,31 @@ import java.time.format.DateTimeFormatter;
 @Component
 @Slf4j
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
-
-    private static void makeResultResponse(
-            HttpServletResponse response,
-            Exception exception
+    // 권한 없는 경우
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException
     ) throws IOException {
+        log.error(accessDeniedException.getClass().getSimpleName() + " Occurs!");
+        this.sendErrorAccessDenied(response);
+    }
+
+    private void sendErrorAccessDenied(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json,charset=utf-8");
+        this.makeResultResponse(response);
+    }
+
+    private void makeResultResponse(HttpServletResponse response) throws IOException {
         try (OutputStream os = response.getOutputStream()) {
             JavaTimeModule javaTimeModule = new JavaTimeModule();
             LocalDateTimeSerializer localDateTimeSerializer = new LocalDateTimeSerializer(
                     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("Asia/Seoul")));
             javaTimeModule.addSerializer(LocalDateTime.class, localDateTimeSerializer);
             ObjectMapper objectMapper = new ObjectMapper().registerModule(javaTimeModule);
-            objectMapper.writeValue(os, ErrorMessage.of(exception, HttpStatus.FORBIDDEN));
+            objectMapper.writeValue(os, ResponseDto.onFailure(ErrorStatus._FORBIDDEN.getCode(), "Authorization Exception", null));
             os.flush();
         }
-    }
-
-    @Override
-    public void handle(HttpServletRequest request,
-                       HttpServletResponse response,
-                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        log.error("AccessDenied Exception Occurs!");
-        sendErrorAccessDenied(response);
-
-    }
-
-    // 권한 없는 경우
-    private void sendErrorAccessDenied(HttpServletResponse response) throws IOException {
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        response.setContentType("application/json,charset=utf-8");
-        makeResultResponse(
-                response,
-                new AccessDeniedException("접근 권한이 없습니다.")
-        );
     }
 }

--- a/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationEntryPoint.java
@@ -72,8 +72,14 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             errorStatus = _JWT_IS_NOT_EXIST;
         } else if (exceptionName.equals("JwtException")) {
             errorStatus = _JWT_IS_NOT_VALID;
+        } else if (exceptionName.equals("RefreshTokenIsNotMatchException")) {
+            errorStatus = _JWT_REFRESH_TOKEN_IS_NOT_MATCH;
+        } else if (exceptionName.equals("RefreshTokenIsNotValidException")) {
+            errorStatus = _JWT_REFRESH_TOKEN_IS_NOT_VALID;
+        } else if (exceptionName.equals("AccessTokenIsValidException")) {
+            errorStatus = _JWT_ACCESS_TOKEN_IS_VALID;
         } else {
-            errorStatus = USER_NOT_FOUND;
+            errorStatus = _INTERNAL_SERVER_ERROR;
         }
         return errorStatus;
     }

--- a/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,7 @@
 package com.example.betteriter.global.filter;
 
-import com.example.betteriter.global.common.response.ResponseDto;
 import com.example.betteriter.global.common.code.status.ErrorStatus;
+import com.example.betteriter.global.common.response.ResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
@@ -10,7 +10,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,6 +18,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
+import static com.example.betteriter.global.common.code.status.ErrorStatus.*;
+
 /**
  * - JwtAuthenticationEntryPoint : JwtAuthenticationFilter 에서 발생한 인증 예외(Authentication Exception(=401)) 처리
  * - commence() 메소드에서 구현
@@ -26,36 +27,54 @@ import java.time.format.DateTimeFormatter;
 @Component
 @Slf4j
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
-    private static void makeResultResponse(
-            HttpServletResponse response,
-            Exception exception
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException
     ) throws IOException {
+        log.error(authException.getClass().getSimpleName() + " Occurs!");
+        this.sendErrorUnauthorized(request, response, authException);
+    }
+
+    private void sendErrorUnauthorized(HttpServletRequest request,
+                                       HttpServletResponse response,
+                                       Exception exception) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json,charset=utf-8");
+        this.makeResultResponse(request, response, this.checkException(request));
+    }
+
+    private String checkException(HttpServletRequest request) {
+        return (String) request.getAttribute("exception");
+    }
+
+    private void makeResultResponse(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String exceptionName
+    ) throws IOException {
+        // HttpServletResponse.getOutputStream() : binary & text
         try (OutputStream os = response.getOutputStream()) {
             JavaTimeModule javaTimeModule = new JavaTimeModule();
             LocalDateTimeSerializer localDateTimeSerializer = new LocalDateTimeSerializer(
                     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("Asia/Seoul")));
             javaTimeModule.addSerializer(LocalDateTime.class, localDateTimeSerializer);
             ObjectMapper objectMapper = new ObjectMapper().registerModule(javaTimeModule);
-            objectMapper.writeValue(os, ResponseDto.onFailure(ErrorStatus._UNAUTHORIZED.getCode(), exception.getClass().getSimpleName(), null));
+            ErrorStatus errorStatus = this.getErrorStatus(exceptionName);
+            objectMapper.writeValue(os, ResponseDto.onFailure(errorStatus.getCode(), exceptionName, null));
             os.flush();
         }
     }
 
-    @Override
-    public void commence(HttpServletRequest request,
-                         HttpServletResponse response,
-                         AuthenticationException authException) throws IOException, ServletException {
-        log.error("Authentication Exception Occurs!");
-        Exception exception = (Exception) request.getAttribute("exception");
-        sendErrorUnauthorized(request, response, exception);
-    }
-
-    // 인증 안된 경우
-    private void sendErrorUnauthorized(HttpServletRequest request,
-                                       HttpServletResponse response,
-                                       Exception exception) throws IOException {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json,charset=utf-8");
-        makeResultResponse(response, exception);
+    private ErrorStatus getErrorStatus(String exceptionName) {
+        ErrorStatus errorStatus;
+        if (exceptionName.equals("InsufficientAuthenticationException")) {
+            errorStatus = _JWT_IS_NOT_EXIST;
+        } else if (exceptionName.equals("JwtException")) {
+            errorStatus = _JWT_IS_NOT_VALID;
+        } else {
+            errorStatus = USER_NOT_FOUND;
+        }
+        return errorStatus;
     }
 }

--- a/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/betteriter/global/filter/JwtAuthenticationFilter.java
@@ -2,7 +2,12 @@ package com.example.betteriter.global.filter;
 
 import com.example.betteriter.fo_domain.user.domain.Users;
 import com.example.betteriter.fo_domain.user.dto.ReissueTokenResponseDto;
+import com.example.betteriter.fo_domain.user.exception.AccessTokenIsValidException;
+import com.example.betteriter.fo_domain.user.exception.RefreshTokenIsNotMatchException;
+import com.example.betteriter.fo_domain.user.exception.RefreshTokenIsNotValidException;
 import com.example.betteriter.fo_domain.user.repository.UsersRepository;
+import com.example.betteriter.global.common.code.status.ErrorStatus;
+import com.example.betteriter.global.common.response.ResponseDto;
 import com.example.betteriter.global.config.properties.JwtProperties;
 import com.example.betteriter.global.config.security.UserAuthentication;
 import com.example.betteriter.global.util.JwtUtil;
@@ -12,8 +17,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -26,8 +29,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import static com.example.betteriter.global.common.code.status.ErrorStatus.*;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 
@@ -70,80 +76,87 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // Case 01) Access Token 재발급인 경우(Authorization Header Access Token 유효성 x)
         if (refreshToken != null && request.getRequestURI().contains("/reissue")) {
             try {
-                String accessToken = this.jwtUtil.extractAccessToken(request)
-                        .orElseThrow(() -> new AuthenticationCredentialsNotFoundException("There is no Access Token"));
-                this.reissueAccessTokenAndRefreshToken(response, accessToken, refreshToken);
-                return;
-            } catch (AuthenticationException exception) {
-                log.info("JwtAuthentication UnauthorizedUserException!");
+                Optional<String> optionalAccessToken = this.jwtUtil.extractAccessToken(request);
+                if (optionalAccessToken.isEmpty()) {
+                    throw new InsufficientAuthenticationException("InsufficientAuthenticationException");
+                }
+                String accessToken = optionalAccessToken.get();
+                this.reissueAccessTokenAndRefreshToken(request, response, accessToken, refreshToken);
+            } catch (Exception exception) {
+                log.error("JwtAuthentication UnauthorizedUserException!");
+                try (OutputStream os = response.getOutputStream()) {
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    objectMapper.writeValue(os, ResponseDto.onFailure(this.getErrorStatus(exception).getCode(), exception.getClass().getSimpleName(), null));
+                    os.flush();
+                }
             }
         }
-
         // Case 02) 일반 API 요청인 경우
         else {
             this.checkAccessTokenAndAuthentication(request, response, filterChain);
+            log.info("jwtAuthentication filter is finished");
+            // Authentication Exception 없이 정상 인증처리 된 경우
+            // 기존 필터 체인 호출 !!
+            filterChain.doFilter(request, response);
         }
+    }
 
-        log.info("jwtAuthentication filter is finished");
-        // Authentication Exception 없이 정상 인증처리 된 경우
-        // 기존 필터 체인 호출 !!
-        filterChain.doFilter(request, response);
+    private void reissueAccessTokenAndRefreshToken(HttpServletRequest request, HttpServletResponse response,
+                                                   String accessToken, String refreshToken
+    ) throws AuthenticationException, IOException {
+        /**
+         * 1. refresh token 유효성 검증
+         * 2. access token 유효성 검증(유효하지 않아야 함)
+         * 3. redis refresh 와 일치 여부 확인
+         **/
+        this.checkAllConditions(accessToken, refreshToken);
+        String newAccessToken = this.jwtUtil.createAccessToken(this.jwtUtil.getUserIdFromToken(accessToken));
+        String newRefreshToken = this.reIssueRefreshToken(this.jwtUtil.getUserIdFromToken(accessToken));
+        this.makeAndSendAccessTokenAndRefreshToken(response, newAccessToken, newRefreshToken);
+    }
+
+    private ErrorStatus getErrorStatus(Exception exception) {
+        if (exception.getClass().equals(RefreshTokenIsNotMatchException.class)) {
+            return _JWT_REFRESH_TOKEN_IS_NOT_MATCH;
+        } else if (exception.getClass().equals(RefreshTokenIsNotValidException.class)) {
+            return _JWT_REFRESH_TOKEN_IS_NOT_VALID;
+        } else if (exception.getClass().equals(AccessTokenIsValidException.class)) {
+            return _JWT_ACCESS_TOKEN_IS_VALID;
+        } else if (exception.getClass().equals(InsufficientAuthenticationException.class)) {
+            return _JWT_IS_NOT_EXIST;
+        } else {
+            return _INTERNAL_SERVER_ERROR;
+        }
     }
 
     // Case 01) Access Token + Refresh Token 재발급 메소드
-    private void reissueAccessTokenAndRefreshToken(HttpServletResponse response,
-                                                   String accessToken,
-                                                   String refreshToken) throws AuthenticationException, IOException {
+    private void checkAllConditions(String accessToken, String refreshToken) {
+        /**
+         * 2. access Token 유효하지 않은지 확인
+         * 1. refresh Token 유효한지 확인
+         * 3. refresh Token 일치하는지 확인
+         **/
+        this.validateAccessToken(accessToken);
+        this.validateRefreshToken(refreshToken);
+        this.isRefreshTokenMatch(refreshToken, accessToken);
+    }
 
-        log.info("reissueAccessTokenAndRefreshToken() called!");
-        // 요청으로 받은 Refresh Token 의 유효성 검증 및 서버 Refresh Token 과 비교
-        try {
-            if (this.validateRefreshToken(refreshToken) || this.isRefreshTokenMatch(refreshToken, accessToken)) {
-                String newAccessToken = this.jwtUtil.createAccessToken(this.jwtUtil.getUserIdFromToken(accessToken));
-                String newRefreshToken = this.reIssueRefreshToken(this.jwtUtil.getUserIdFromToken(accessToken));
-                this.sendAccessTokenAndRefreshToken(response, newAccessToken, newRefreshToken);
-            }
-        } catch (IllegalArgumentException | JwtException exception) {
-            throw new BadCredentialsException("Authentication Error Occurred");
+    private void validateRefreshToken(String refreshToken) {
+        if (!this.jwtUtil.validateToken(refreshToken)) {
+            throw new RefreshTokenIsNotValidException("RefreshTokenIsNotValid Exception");
         }
     }
 
-    /**
-     * - 재 발급한 refresh & access token 응답으로 보내는 메소드
-     * 1. 상태 코드 설정
-     * 2. 응답 헤더에 설정 (jwtProperties 에서 정보 가져옴)
-     **/
-    private void sendAccessTokenAndRefreshToken(HttpServletResponse response,
-                                                String accessToken,
-                                                String refreshToken) throws IOException {
-        LocalDateTime expireTime = LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000);
-        // refresh token, access token 을 응답 본문에 넣어 응답
-        ReissueTokenResponseDto reissueTokenResponseDto = ReissueTokenResponseDto.builder()
-                .accessToken(this.jwtProperties.getBearer() + " " + accessToken)
-                .refreshToken(refreshToken)
-                .expiredTime(expireTime)
-                .build();
-
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-
-        response.setStatus(SC_OK);
-        response.setContentType("application/json"); // JSON 형태로 응답
-        response.setCharacterEncoding("UTF-8");
-        String jsonResponse = mapper.writeValueAsString(reissueTokenResponseDto);
-        response.getWriter().write(jsonResponse);
-        response.flushBuffer();
+    private void validateAccessToken(String accessToken) {
+        if (this.jwtUtil.validateToken(accessToken)) {
+            throw new AccessTokenIsValidException();
+        }
     }
 
-
-    private boolean isRefreshTokenMatch(String refreshToken, String accessToken) {
-        String userId = this.jwtUtil.getUserIdFromToken(accessToken);
-        String storedRefreshToken = this.redisUtil.getData(userId);
-        return refreshToken.equals(storedRefreshToken);
-    }
-
-    private boolean validateRefreshToken(String refreshToken) {
-        return this.jwtUtil.validateToken(refreshToken);
+    private void isRefreshTokenMatch(String refreshToken, String accessToken) {
+        if (!refreshToken.equals(this.redisUtil.getData(this.jwtUtil.getUserIdFromToken(accessToken)))) {
+            throw new RefreshTokenIsNotMatchException();
+        }
     }
 
     /**
@@ -154,9 +167,41 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String reIssueRefreshToken(String userId) {
         this.redisUtil.deleteData(userId); // 기존 refresh token 삭제
         String reIssuedRefreshToken = jwtUtil.createRefreshToken();
-        this.redisUtil.setData(userId, reIssuedRefreshToken); // refresh token 저장
+        this.redisUtil.setDataExpire(userId, reIssuedRefreshToken, this.jwtProperties.getRefreshExpiration()); // refresh token 저장
         return reIssuedRefreshToken;
     }
+
+    /**
+     * - 재 발급한 refresh & access token 응답으로 보내는 메소드
+     * 1. 상태 코드 설정
+     * 2. 응답 헤더에 설정 (jwtProperties 에서 정보 가져옴)
+     **/
+    private void makeAndSendAccessTokenAndRefreshToken(HttpServletResponse response,
+                                                       String accessToken,
+                                                       String refreshToken) throws IOException {
+        LocalDateTime expireTime = LocalDateTime.now().plusSeconds(this.jwtProperties.getAccessExpiration() / 1000);
+        // refresh token, access token 을 응답 본문에 넣어 응답
+        ReissueTokenResponseDto reissueTokenResponseDto = ReissueTokenResponseDto.builder()
+                .accessToken(this.jwtProperties.getBearer() + " " + accessToken)
+                .refreshToken(refreshToken)
+                .expiredTime(expireTime)
+                .build();
+        this.makeResultResponse(response, reissueTokenResponseDto);
+    }
+
+    private void makeResultResponse(HttpServletResponse response,
+                                    ReissueTokenResponseDto responseDto
+    ) throws IOException {
+        response.setStatus(SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        try (OutputStream os = response.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+            objectMapper.writeValue(os, ResponseDto.onSuccess(responseDto));
+        }
+    }
+
 
     /**
      * - 일반 API 호출을 처리하는 메소드

--- a/src/main/java/com/example/betteriter/global/util/JwtUtil.java
+++ b/src/main/java/com/example/betteriter/global/util/JwtUtil.java
@@ -61,9 +61,8 @@ public class JwtUtil {
                     .getBody()
                     .getSubject();
         } catch (Exception exception) {
-            log.error("Access Token is not valid");
+            throw new JwtException("Access Token is not valid");
         }
-        return null;
     }
 
     // kakao oauth 로그인 & 일반 로그인 시 jwt 응답 생성 + redis refresh 저장


### PR DESCRIPTION
### PR 제목

- 인증 과정에서 발생하는 응답 코드 구조 세분화를 진행하면 회원 탈퇴 API 리팩토링 진행합니다.

### PR 생성 날짜

- 2023/11/28

### PR 내용

- 회원 탈퇴 API 컨트롤러 `경로 변수` -> `쿼리 스트링` 으로 변경
- `JwtAuthenticaionEntryPoint` 응답 구조 세분화
- `JwtAceessDeniedHandler` 응답 구조 세분화
- `ErrorStatus` 추가
-  Access Token 재발급 로직 및 응답 구조 리팩토링

### 첨부 자료

- x

### 관련 이슈

- close #99 