### PR TITLE
[FEATURE-121] Job Enum class 추가 및 리뷰 상세 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/example/betteriter/fo_domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/betteriter/fo_domain/comment/domain/Comment.java
@@ -14,6 +14,97 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import com.example.betteriter.fo_domain.review.domain.Review;
+import com.example.betteriter.fo_domain.user.domain.Users;
+import com.example.betteriter.global.common.entity.BaseEntity;
+import com.example.betteriter.global.constant.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
 
 @Slf4j
 @Getter

--- a/src/main/java/com/example/betteriter/fo_domain/review/dto/ReviewDetailResponse.java
+++ b/src/main/java/com/example/betteriter/fo_domain/review/dto/ReviewDetailResponse.java
@@ -120,6 +120,7 @@ public class ReviewDetailResponse {
 
         public static ReviewDetailResponse.GetUserResponseDto from(Users writer) {
             return ReviewDetailResponse.GetUserResponseDto.builder()
+                    .id(writer.getId())
                     .nickName(writer.getUsersDetail().getNickName())
                     .job(writer.getUsersDetail().getJob())
                     .isExpert(writer.isExpert())

--- a/src/main/java/com/example/betteriter/fo_domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/betteriter/fo_domain/review/service/ReviewService.java
@@ -115,7 +115,7 @@ public class ReviewService {
                 = this.reviewRepository.findTop4ByProductNameOrderByScrapedCntPlusLikedCntDesc(review.getProductName());
 
         if (relatedReviews.size() == 4) {
-            return ReviewDetailResponse.of(review, relatedReviews);
+            return ReviewDetailResponse.of(review, relatedReviews, getCurrentUser());
         }
         int remain = 4 - relatedReviews.size();
         // 3. 동일한 카테고리 중 좋아요 + 스크랩 순 정렬 조회 (나머지)
@@ -125,7 +125,7 @@ public class ReviewService {
         List<Review> totalRelatedReviews = Stream.concat(relatedReviews.stream(), restRelatedReviews.stream())
                 .collect(Collectors.toList());
 
-        return ReviewDetailResponse.of(review, totalRelatedReviews);
+        return ReviewDetailResponse.of(review, totalRelatedReviews, getCurrentUser());
     }
 
     /* 리뷰 좋아요 */

--- a/src/main/java/com/example/betteriter/global/constant/Job.java
+++ b/src/main/java/com/example/betteriter/global/constant/Job.java
@@ -8,10 +8,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Job {
-    DEVELOPER("개발자"),
+    SW_DEVELOPER("SW 개발자"),
+    GAME_DEVELOPER("게임 개발자"),
     STUDENT("학생"),
     TEACHER("선생님"),
-    DESIGNER("디자이너");
+    VIDEO_DESIGNER("영상 디자이너"),
+    VISUAL_DESIGNER("시각 디자이너"),
+    DATA_ANALYST("데이터 분석가"),
+    PLANNER("기획자"),
+    EDITOR("에디터"),
+    CEO("CEO");
     private final String jobName;
 
     @JsonCreator

--- a/src/test/java/com/example/betteriter/fo_domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/betteriter/fo_domain/review/controller/ReviewControllerTest.java
@@ -49,6 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RedisUtil.class),
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class)}
 )
+@WithMockUser
 class ReviewControllerTest {
 
     @Autowired
@@ -502,5 +503,105 @@ class ReviewControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk());
 
+    }
+
+    @Test
+    @DisplayName("리뷰 상세 조회 API 리팩토링에 대한 컨트롤러 테스트를 진행한다.")
+    void getReviewDetailTest() throws Exception {
+        // given
+
+        Users users = Users.builder()
+                .id(1L)
+                .email("email")
+                .roleType(ROLE_USER)
+                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.SW_DEVELOPER).build())
+                .build();
+
+        Review review = Review.builder()
+                .writer(users)
+                .category(PC)
+                .productName("productName")
+                .category(PC)
+                .price(10)
+                .storeName(1)
+                .status(ACTIVE)
+                .boughtAt(LocalDate.now())
+                .starPoint(1)
+                .goodPoint("goodPoint")
+                .badPoint("badPoint")
+                .shortReview("short")
+                .build();
+
+        GetReviewDetailResponseDto getReviewDetailResponseDto = GetReviewDetailResponseDto.builder()
+                .id(1L)
+                .productName("productName")
+                .reviewSpecData(List.of("spec1", "spec2"))
+                .starPoint(2.0)
+                .goodPoint("goodPoint")
+                .badPoint("badPoint")
+                .shortReview("shortReview")
+                .manufacturer("삼성")
+                .storeName(1)
+                .boughtAt(LocalDate.of(2023, 12, 12))
+                .createdAt(LocalDate.of(2023, 12, 22))
+                .reviewImages(List.of(GetReviewImageResponseDto.builder().imgUrl("imageUrl").orderNum(1).build()))
+                .scrapedCount(2L)
+                .build();
+
+        ReviewDetailResponse.GetUserResponseDto writerInfo = ReviewDetailResponse.GetUserResponseDto.builder()
+                .id(1L)
+                .nickName("nickName")
+                .job(Job.SW_DEVELOPER)
+                .profileImage("profileImage")
+                .isExpert(true)
+                .build();
+
+        List<ReviewDetailResponse.GetRelatedReviewResponseDto> getRelatedReviewResponseDtos
+                = List.of(ReviewDetailResponse.GetRelatedReviewResponseDto.builder().productName("productName")
+                .reviewImage("reviewImage")
+                .writerName("동근")
+                .isExpert(true).build());
+
+        ReviewDetailResponse.ReviewLikeInfo reviewLikeInfo = ReviewDetailResponse.ReviewLikeInfo.builder()
+                .reviewLikeUserInfo(List.of(ReviewDetailResponse.GetUserResponseForLikeAndComment.builder()
+                        .nickName("nickName")
+                        .job(Job.SW_DEVELOPER)
+                        .profileImage("profileImage")
+                        .build()))
+                .reviewLikedCount(2L)
+                .build();
+
+        ReviewDetailResponse.ReviewCommentInfo reviewCommentInfo = ReviewDetailResponse.ReviewCommentInfo.builder().
+                reviewCommentCount(2L)
+                .reviewCommentResponses(List.of(ReviewDetailResponse.ReviewCommentInfo.ReviewCommentResponse.builder()
+                        .reviewCommentUserInfo(ReviewDetailResponse.GetUserResponseForLikeAndComment.builder()
+                                .nickName("nickName")
+                                .job(Job.SW_DEVELOPER)
+                                .profileImage("profileImage")
+                                .build())
+                        .comment("comment")
+                        .commentCreatedAt(LocalDate.now())
+                        .isMine(true)
+                        .build()))
+                .build();
+
+        ReviewDetailResponse response = ReviewDetailResponse.builder()
+                .getReviewDetailResponseDto(getReviewDetailResponseDto)
+                .writerInfo(writerInfo)
+                .getRelatedReviewResponseDto(getRelatedReviewResponseDtos)
+                .reviewLikeInfo(reviewLikeInfo)
+                .reviewCommentInfo(reviewCommentInfo)
+                .build();
+
+        given(this.reviewService.getReviewDetail(anyLong()))
+                .willReturn(response);
+        // when & then
+        mockMvc.perform(get("/review/detail/{reviewId}", 1L))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.writerInfo.id").value(1))
+                .andExpect(jsonPath("$.result.relatedReviews[0].productName").value("productName"))
+                .andExpect(jsonPath("$.result.reviewCommentInfo.reviewComments[0].mine").value(true));
     }
 }

--- a/src/test/java/com/example/betteriter/fo_domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/betteriter/fo_domain/review/controller/ReviewControllerTest.java
@@ -3,7 +3,6 @@ package com.example.betteriter.fo_domain.review.controller;
 import com.example.betteriter.bo_domain.menufacturer.domain.Manufacturer;
 import com.example.betteriter.fo_domain.review.domain.Review;
 import com.example.betteriter.fo_domain.review.domain.ReviewImage;
-import com.example.betteriter.fo_domain.review.domain.ReviewScrap;
 import com.example.betteriter.fo_domain.review.dto.*;
 import com.example.betteriter.fo_domain.review.dto.CreateReviewRequestDto.CreateReviewImageRequestDto;
 import com.example.betteriter.fo_domain.review.service.ReviewService;
@@ -12,7 +11,6 @@ import com.example.betteriter.fo_domain.user.domain.UsersDetail;
 import com.example.betteriter.global.config.security.SecurityConfig;
 import com.example.betteriter.global.constant.Category;
 import com.example.betteriter.global.constant.Job;
-import com.example.betteriter.global.constant.RoleType;
 import com.example.betteriter.global.filter.JwtAuthenticationFilter;
 import com.example.betteriter.global.util.JwtUtil;
 import com.example.betteriter.global.util.RedisUtil;
@@ -39,7 +37,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -68,7 +65,7 @@ class ReviewControllerTest {
         Users users = Users.builder()
                 .email("email")
                 .roleType(ROLE_USER)
-                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.DEVELOPER).build())
+                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.SW_DEVELOPER).build())
                 .build();
 
 
@@ -114,7 +111,7 @@ class ReviewControllerTest {
                 .usersDetail(UsersDetail.builder()
                         .nickName("nickName")
                         .profileImage("profileImage")
-                        .job(Job.DEVELOPER)
+                        .job(Job.SW_DEVELOPER)
                         .build())
                 .build();
 
@@ -161,7 +158,7 @@ class ReviewControllerTest {
                 .usersDetail(UsersDetail.builder()
                         .nickName("nickName")
                         .profileImage("profileImage")
-                        .job(Job.DEVELOPER)
+                        .job(Job.SW_DEVELOPER)
                         .build())
                 .build();
 
@@ -241,7 +238,7 @@ class ReviewControllerTest {
                 .usersDetail(UsersDetail.builder()
                         .nickName("nickName")
                         .profileImage("profileImage")
-                        .job(Job.DEVELOPER)
+                        .job(Job.SW_DEVELOPER)
                         .build())
                 .build();
 
@@ -291,7 +288,7 @@ class ReviewControllerTest {
         Users users = Users.builder()
                 .email("email")
                 .roleType(ROLE_USER)
-                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.DEVELOPER).build())
+                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.SW_DEVELOPER).build())
                 .build();
 
         Review review = Review.builder()
@@ -344,7 +341,7 @@ class ReviewControllerTest {
         Users users = Users.builder()
                 .email("email")
                 .roleType(ROLE_USER)
-                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.DEVELOPER).build())
+                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.SW_DEVELOPER).build())
                 .build();
 
         Review review = Review.builder()
@@ -394,7 +391,7 @@ class ReviewControllerTest {
         Users users = Users.builder()
                 .email("email")
                 .roleType(ROLE_USER)
-                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.DEVELOPER).build())
+                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.SW_DEVELOPER).build())
                 .build();
 
         Review review = Review.builder()
@@ -431,7 +428,7 @@ class ReviewControllerTest {
         ReviewDetailResponse.GetUserResponseDto writerInfo = ReviewDetailResponse.GetUserResponseDto.builder()
                 .id(1L)
                 .nickName("nickName")
-                .job(Job.DEVELOPER)
+                .job(Job.SW_DEVELOPER)
                 .profileImage("profileImage")
                 .isExpert(true)
                 .build();
@@ -445,7 +442,7 @@ class ReviewControllerTest {
         ReviewDetailResponse.ReviewLikeInfo reviewLikeInfo = ReviewDetailResponse.ReviewLikeInfo.builder()
                 .reviewLikeUserInfo(List.of(ReviewDetailResponse.GetUserResponseForLikeAndComment.builder()
                         .nickName("nickName")
-                        .job(Job.DEVELOPER)
+                        .job(Job.SW_DEVELOPER)
                         .profileImage("profileImage")
                         .build()))
                 .reviewLikedCount(2L)
@@ -456,7 +453,7 @@ class ReviewControllerTest {
                 .reviewCommentResponses(List.of(ReviewDetailResponse.ReviewCommentInfo.ReviewCommentResponse.builder()
                         .reviewCommentUserInfo(ReviewDetailResponse.GetUserResponseForLikeAndComment.builder()
                                 .nickName("nickName")
-                                .job(Job.DEVELOPER)
+                                .job(Job.SW_DEVELOPER)
                                 .profileImage("profileImage")
                                 .build())
                         .comment("comment")
@@ -504,31 +501,6 @@ class ReviewControllerTest {
                         .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk());
-    }
 
-    @Test
-    @WithMockUser
-    @DisplayName("리뷰 스크랩 컨트롤러 테스트를 진행한다.")
-    void reviewScrapControllerTest() throws Exception {
-        // given
-
-        // 스크랩 하는 리뷰
-        Review review = createReview(1L);
-
-        // 스크랩 하는 유저
-        Users users = Users.builder()
-                .id(1L)
-                .email("email")
-                .roleType(ROLE_USER)
-                .build();
-
-        given(this.reviewService.reviewScrap(anyLong()))
-                .willReturn(ReviewScrap.builder().review(review).users(users).build());
-
-        // when & then
-        mockMvc.perform(post("/review/scrap/{reviewId}",1L).with(csrf()))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true));
     }
 }

--- a/src/test/java/com/example/betteriter/fo_domain/review/service/ReviewServiceIntegratedTest.java
+++ b/src/test/java/com/example/betteriter/fo_domain/review/service/ReviewServiceIntegratedTest.java
@@ -31,7 +31,7 @@ public class ReviewServiceIntegratedTest {
         Users users = Users.builder()
                 .usersDetail(UsersDetail.builder()
                         .nickName("nickName")
-                        .job(Job.DEVELOPER)
+                        .job(Job.SW_DEVELOPER)
                         .profileImage("profileImage")
                         .build())
                 .build();

--- a/src/test/java/com/example/betteriter/fo_domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/betteriter/fo_domain/review/service/ReviewServiceTest.java
@@ -77,7 +77,7 @@ public class ReviewServiceTest {
         Users users = Users.builder()
                 .email("email")
                 .roleType(ROLE_USER)
-                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.DEVELOPER).build())
+                .usersDetail(UsersDetail.builder().nickName("nickname").job(Job.SW_DEVELOPER).build())
                 .build();
 
 
@@ -214,7 +214,7 @@ public class ReviewServiceTest {
                 .isExpert(true)
                 .usersDetail(UsersDetail.builder()
                         .nickName("nickname")
-                        .job(Job.DEVELOPER).build())
+                        .job(Job.SW_DEVELOPER).build())
                 .build();
 
 

--- a/src/test/java/com/example/betteriter/fo_domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/betteriter/fo_domain/user/service/UserServiceTest.java
@@ -79,7 +79,7 @@ public class UserServiceTest {
                 .roleType(RoleType.ROLE_USER)
                 .isExpert(true)
                 .usersDetail(UsersDetail.builder()
-                        .job(Job.DESIGNER)
+                        .job(Job.SW_DEVELOPER)
                         .profileImage("profileImage")
                         .build())
                 .build();
@@ -107,7 +107,7 @@ public class UserServiceTest {
                 .roleType(RoleType.ROLE_USER)
                 .isExpert(true)
                 .usersDetail(UsersDetail.builder()
-                        .job(Job.DESIGNER)
+                        .job(Job.SW_DEVELOPER)
                         .profileImage("profileImage")
                         .build())
                 .build();

--- a/src/test/java/com/example/betteriter/global/DeserializerTest.java
+++ b/src/test/java/com/example/betteriter/global/DeserializerTest.java
@@ -116,7 +116,7 @@ public class DeserializerTest {
                 .email("danaver12@daum.net")
                 .password("1234")
                 .nickName("nickname")
-                .job(Job.DESIGNER)
+                .job(Job.SW_DEVELOPER)
                 .build();
 
         String json = new ObjectMapper().writeValueAsString(joinDto);


### PR DESCRIPTION
### PR 제목

- 기존 Job enum class 상수 추가 및 리뷰 상세 조회 API 을 리팩토링합니다.

### PR 생성 날짜

- 2023/12/22

### PR 내용

- 리뷰 상세 조회 API 내가 쓴 댓글인지 여부 `isMine` 필드로 반환
- Job 직업 정보 추가 및 수정
- 테스트 코드 작성 및 테스트

### 첨부 자료

- 직업 리스트 : SW 개발자, 게임 개발자, 학생, 선생님, 영상 디자이너, 시각 디자이너, 데이터 분석가, 기획자, 에디터, CEO

### 관련 이슈

- close #121 